### PR TITLE
fix(api): add real database health checks to /health endpoint

### DIFF
--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/src/**/*.test.ts'],
+  transform: {
+    '^.+\\.tsx?$': [
+      'ts-jest',
+      {
+        diagnostics: false,
+        isolatedModules: true,
+        tsconfig: {
+          module: 'commonjs',
+          esModuleInterop: true,
+          allowSyntheticDefaultImports: true,
+          strict: false,
+        },
+      },
+    ],
+  },
+  moduleNameMapper: {},
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
+};

--- a/packages/api/src/database/connection.test.ts
+++ b/packages/api/src/database/connection.test.ts
@@ -1,0 +1,208 @@
+import { DatabaseConnection, type HealthCheckResult } from '../database/connection';
+
+jest.mock('pg', () => {
+  const mockPool = {
+    totalCount: 5,
+    idleCount: 3,
+    waitingCount: 0,
+    connect: jest.fn(),
+    end: jest.fn(),
+    query: jest.fn(),
+    on: jest.fn(),
+  };
+  return {
+    Pool: jest.fn(() => mockPool),
+    __mockPool: mockPool,
+  };
+});
+
+jest.mock('redis', () => {
+  const mockRedis = {
+    connect: jest.fn().mockResolvedValue(undefined),
+    disconnect: jest.fn().mockResolvedValue(undefined),
+    ping: jest.fn().mockResolvedValue('PONG'),
+    set: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn().mockResolvedValue(null),
+    del: jest.fn().mockResolvedValue(1),
+    dbsize: jest.fn().mockResolvedValue(0),
+    info: jest.fn().mockResolvedValue('used_memory:1000000'),
+    setEx: jest.fn().mockResolvedValue('OK'),
+    exists: jest.fn().mockResolvedValue(0),
+    incr: jest.fn().mockResolvedValue(1),
+    expire: jest.fn().mockResolvedValue(1),
+    on: jest.fn(),
+  };
+  return {
+    createClient: jest.fn(() => mockRedis),
+    __mockRedis: mockRedis,
+  };
+});
+
+const { __mockPool } = require('pg');
+const { __mockRedis } = require('redis');
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __mockPool.query.mockReset();
+  __mockRedis.ping.mockReset();
+
+  __mockPool.query.mockResolvedValue({ rows: [{ health_check: 1 }] });
+  __mockRedis.ping.mockResolvedValue('PONG');
+
+  __mockPool.totalCount = 5;
+  __mockPool.idleCount = 3;
+  __mockPool.waitingCount = 0;
+});
+
+process.env.DATABASE_URL = 'postgres://test:test@localhost:5432/test';
+process.env.REDIS_URL = 'redis://localhost:6379';
+
+describe('DatabaseConnection.healthCheck', () => {
+  it('returns healthy status when all services respond', async () => {
+    // Simulate DB size query
+    __mockPool.query.mockImplementation((sql: string) => {
+      if (sql.includes('pg_database_size')) {
+        return Promise.resolve({ rows: [{ size_bytes: '1048576' }] });
+      }
+      if (sql.includes('pg_is_in_recovery')) {
+        return Promise.resolve({
+          rows: [{ is_replica: false, lag_ms: '0' }],
+        });
+      }
+      return Promise.resolve({ rows: [{ health_check: 1 }] });
+    });
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.status).toBe('healthy');
+    expect(result.postgres.status).toBe('connected');
+    expect(result.postgres.poolStats.total).toBe(5);
+    expect(result.postgres.poolStats.idle).toBe(3);
+    expect(result.postgres.poolStats.waiting).toBe(0);
+    expect(result.postgres.poolStats.max).toBe(20);
+    expect(result.redis.status).toBe('connected');
+    expect(result.database.sizeBytes).toBe(1048576);
+    expect(result.database.sizeFormatted).toBe('1 MB');
+    expect(result.replication.isReplica).toBe(false);
+    expect(result.replication.lagMs).toBeNull();
+    expect(result.queryMetrics.totalQueries).toBeGreaterThanOrEqual(0);
+    expect(typeof result.postgres.latencyMs).toBe('number');
+    expect(typeof result.redis.latencyMs).toBe('number');
+    expect(typeof result.timestamp).toBe('string');
+  });
+
+  it('returns unhealthy when postgres fails', async () => {
+    __mockPool.query.mockRejectedValue(new Error('connection refused'));
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.postgres.status).toBe('error');
+  });
+
+  it('returns unhealthy when redis fails', async () => {
+    __mockRedis.ping.mockRejectedValue(new Error('connection refused'));
+    __mockPool.query.mockImplementation((sql: string) => {
+      if (sql.includes('pg_database_size')) {
+        return Promise.resolve({ rows: [{ size_bytes: '0' }] });
+      }
+      if (sql.includes('pg_is_in_recovery')) {
+        return Promise.resolve({
+          rows: [{ is_replica: false, lag_ms: '0' }],
+        });
+      }
+      return Promise.resolve({ rows: [{ health_check: 1 }] });
+    });
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.status).toBe('unhealthy');
+    expect(result.redis.status).toBe('error');
+  });
+
+  it('returns degraded when postgres latency is high', async () => {
+    __mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('SELECT 1 AS health_check')) {
+        return new Promise((resolve) =>
+          setTimeout(() => resolve({ rows: [{ health_check: 1 }] }), 600)
+        );
+      }
+      if (sql.includes('pg_database_size')) {
+        return { rows: [{ size_bytes: '0' }] };
+      }
+      if (sql.includes('pg_is_in_recovery')) {
+        return { rows: [{ is_replica: false, lag_ms: '0' }] };
+      }
+      return { rows: [{ health_check: 1 }] };
+    });
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.status).toBe('degraded');
+  });
+
+  it('detects replication when isReplica is true', async () => {
+    __mockPool.query.mockImplementation((sql: string) => {
+      if (sql.includes('pg_database_size')) {
+        return Promise.resolve({ rows: [{ size_bytes: '2097152' }] });
+      }
+      if (sql.includes('pg_is_in_recovery')) {
+        return Promise.resolve({
+          rows: [{ is_replica: true, lag_ms: '1500' }],
+        });
+      }
+      return Promise.resolve({ rows: [{ health_check: 1 }] });
+    });
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.replication.isReplica).toBe(true);
+    expect(result.replication.lagMs).toBe(1500);
+    expect(result.database.sizeFormatted).toBe('2 MB');
+  });
+
+  it('formats database sizes correctly', async () => {
+    __mockPool.query.mockImplementation((sql: string) => {
+      if (sql.includes('pg_database_size')) {
+        return Promise.resolve({ rows: [{ size_bytes: '1073741824' }] });
+      }
+      if (sql.includes('pg_is_in_recovery')) {
+        return Promise.resolve({
+          rows: [{ is_replica: false, lag_ms: '0' }],
+        });
+      }
+      return Promise.resolve({ rows: [{ health_check: 1 }] });
+    });
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.database.sizeFormatted).toBe('1 GB');
+  });
+
+  it('handles database size query failure gracefully', async () => {
+    let callCount = 0;
+    __mockPool.query.mockImplementation((sql: string) => {
+      callCount++;
+      if (sql.includes('pg_database_size')) {
+        return Promise.reject(new Error('permission denied'));
+      }
+      if (sql.includes('pg_is_in_recovery')) {
+        return Promise.reject(new Error('not supported'));
+      }
+      return Promise.resolve({ rows: [{ health_check: 1 }] });
+    });
+
+    const db = DatabaseConnection.getInstance();
+    const result = await db.healthCheck();
+
+    expect(result.database.sizeBytes).toBe(0);
+    expect(result.database.sizeFormatted).toBe('unknown');
+    expect(result.replication.isReplica).toBe(false);
+  });
+});

--- a/packages/api/src/database/connection.ts
+++ b/packages/api/src/database/connection.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolClient } from 'pg';
 import { createClient } from 'redis';
 import winston from 'winston';
-import { recordQueryExecution } from './query-monitor';
+import { recordQueryExecution, getQueryMetrics } from './query-monitor';
 
 // Cache TTL constants (in seconds)
 export const CACHE_TTL = {
@@ -10,6 +10,40 @@ export const CACHE_TTL = {
   ACCOUNT_STATS: 300,
   ASSET_DATA: 300,
 } as const;
+
+export interface PoolStats {
+  total: number;
+  idle: number;
+  waiting: number;
+  max: number;
+}
+
+export interface HealthCheckResult {
+  status: 'healthy' | 'degraded' | 'unhealthy';
+  postgres: {
+    status: 'connected' | 'disconnected' | 'error';
+    latencyMs: number;
+    poolStats: PoolStats;
+  };
+  redis: {
+    status: 'connected' | 'disconnected' | 'error';
+    latencyMs: number;
+  };
+  database: {
+    sizeBytes: number;
+    sizeFormatted: string;
+  };
+  replication: {
+    isReplica: boolean;
+    lagMs: number | null;
+  };
+  queryMetrics: {
+    totalQueries: number;
+    slowQueries: number;
+    averageDurationMs: number;
+  };
+  timestamp: string;
+}
 
 export class DatabaseConnection {
   private static instance: DatabaseConnection;
@@ -172,6 +206,150 @@ export class DatabaseConnection {
     const key = `cache:${metric}:${today}`;
     const value = await this.redis.get(key);
     return value ? parseInt(value) : 0;
+  }
+
+  public async healthCheck(): Promise<HealthCheckResult> {
+    const pgResult = await this.checkPostgresHealth();
+    const redisResult = await this.checkRedisHealth();
+    const dbSize = await this.getDatabaseSize();
+    const replLag = await this.getReplicationLag();
+    const queryMetrics = await this.getQueryMetricsSnapshot();
+
+    let status: 'healthy' | 'degraded' | 'unhealthy' = 'healthy';
+
+    if (pgResult.status === 'error' || redisResult.status === 'error') {
+      status = 'unhealthy';
+    } else if (pgResult.latencyMs > 500 || redisResult.latencyMs > 100) {
+      status = 'degraded';
+    }
+
+    return {
+      status,
+      postgres: {
+        status: pgResult.status,
+        latencyMs: pgResult.latencyMs,
+        poolStats: pgResult.poolStats,
+      },
+      redis: {
+        status: redisResult.status,
+        latencyMs: redisResult.latencyMs,
+      },
+      database: dbSize,
+      replication: replLag,
+      queryMetrics,
+      timestamp: new Date().toISOString(),
+    };
+  }
+
+  private async checkPostgresHealth(): Promise<{
+    status: 'connected' | 'disconnected' | 'error';
+    latencyMs: number;
+    poolStats: PoolStats;
+  }> {
+    const start = performance.now();
+    try {
+      await this.pool.query('SELECT 1 AS health_check');
+      const latencyMs = Math.round((performance.now() - start) * 100) / 100;
+      return {
+        status: 'connected',
+        latencyMs,
+        poolStats: {
+          total: this.pool.totalCount,
+          idle: this.pool.idleCount,
+          waiting: this.pool.waitingCount,
+          max: 20,
+        },
+      };
+    } catch {
+      return {
+        status: 'error',
+        latencyMs: Math.round((performance.now() - start) * 100) / 100,
+        poolStats: {
+          total: this.pool.totalCount,
+          idle: this.pool.idleCount,
+          waiting: this.pool.waitingCount,
+          max: 20,
+        },
+      };
+    }
+  }
+
+  private async checkRedisHealth(): Promise<{
+    status: 'connected' | 'disconnected' | 'error';
+    latencyMs: number;
+  }> {
+    const start = performance.now();
+    try {
+      await this.redis.ping();
+      const latencyMs = Math.round((performance.now() - start) * 100) / 100;
+      return { status: 'connected', latencyMs };
+    } catch {
+      return {
+        status: 'error',
+        latencyMs: Math.round((performance.now() - start) * 100) / 100,
+      };
+    }
+  }
+
+  private async getDatabaseSize(): Promise<{
+    sizeBytes: number;
+    sizeFormatted: string;
+  }> {
+    try {
+      const result = await this.pool.query(`
+        SELECT pg_database_size(current_database()) AS size_bytes
+      `);
+      const sizeBytes = parseInt(result.rows[0]?.size_bytes ?? '0', 10);
+      const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+      let size = sizeBytes;
+      let unitIndex = 0;
+      while (size >= 1024 && unitIndex < units.length - 1) {
+        size /= 1024;
+        unitIndex++;
+      }
+      return {
+        sizeBytes,
+        sizeFormatted: `${Math.round(size * 100) / 100} ${units[unitIndex]}`,
+      };
+    } catch {
+      return { sizeBytes: 0, sizeFormatted: 'unknown' };
+    }
+  }
+
+  private async getReplicationLag(): Promise<{
+    isReplica: boolean;
+    lagMs: number | null;
+  }> {
+    try {
+      const result = await this.pool.query(
+        `SELECT
+          CASE WHEN pg_is_in_recovery() THEN true ELSE false END AS is_replica,
+          COALESCE(
+            EXTRACT(EPOCH FROM (pg_last_wal_receive_lsn() - pg_last_wal_replay_lsn())) * 1000,
+            0
+          ) AS lag_ms`
+      );
+      const row = result.rows[0] ?? { is_replica: false, lag_ms: 0 };
+      return {
+        isReplica: row.is_replica,
+        lagMs: row.is_replica ? Number(row.lag_ms) : null,
+      };
+    } catch {
+      return { isReplica: false, lagMs: null };
+    }
+  }
+
+  private async getQueryMetricsSnapshot(): Promise<{
+    totalQueries: number;
+    slowQueries: number;
+    averageDurationMs: number;
+  }> {
+    const metrics = getQueryMetrics();
+    return {
+      totalQueries: metrics.totalQueries,
+      slowQueries: metrics.slowQueries,
+      averageDurationMs: metrics.averageDurationMs,
+    };
   }
 }
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -18,6 +18,7 @@ import { resolvers } from './resolvers';
 import { db } from './database/connection';
 import { createLoaders } from './loaders';
 import { formatQueryMetricsPrometheus, getQueryMetrics } from './database/query-monitor';
+import type { HealthCheckResult } from './database/connection';
 import { RealtimePublisher } from './services/realtime-publisher';
 import { 
   checkSubscriptionRateLimit, 
@@ -77,10 +78,6 @@ class ApiServer {
 
     this.app.use(compression());
 
-    const isProduction = process.env.NODE_ENV === 'production';
-
-    const logger = this.logger;
-
     const limiter = rateLimit({
       windowMs: 60 * 1000,
       max: 1000,
@@ -100,16 +97,22 @@ class ApiServer {
     });
     this.app.use('/graphql', limiter);
 
-    this.app.get('/health', (req, res) => {
-      res.json({
-        status: 'healthy',
-        timestamp: new Date().toISOString(),
-        uptime: process.uptime(),
-        environment: isProduction ? 'production' : 'development',
-      });
+    this.app.get('/health', async (_req, res) => {
+      try {
+        const health: HealthCheckResult = await db.healthCheck();
+        const statusCode = health.status === 'unhealthy' ? 503
+          : health.status === 'degraded' ? 200
+          : 200;
+        res.status(statusCode).json(health);
+      } catch (error: any) {
+        res.status(503).json({
+          status: 'unhealthy',
+          timestamp: new Date().toISOString(),
+          error: error?.message ?? 'Health check failed',
+        });
+      }
     });
 
-    // Metrics endpoint
     this.app.get('/metrics', (_req, res) => {
       res.set('Content-Type', 'text/plain');
       res.send(
@@ -124,16 +127,6 @@ class ApiServer {
 
     this.app.get('/metrics/queries', (_req, res) => {
       res.json(getQueryMetrics());
-    this.app.get('/metrics', (req, res) => {
-      res.set('Content-Type', 'text/plain');
-      res.send([
-        '# HELP graphql_server_status Status of the GraphQL server',
-        '# TYPE graphql_server_status gauge',
-        'graphql_server_status 1',
-        '# HELP graphql_requests_total Total number of GraphQL requests',
-        '# TYPE graphql_requests_total counter',
-        'graphql_requests_total 0',
-      ].join('\n'));
     });
   }
 


### PR DESCRIPTION
## Summary

Implements real database health checks for the API server's `/health` endpoint (previously a static stub).

## Changes

- **`DatabaseConnection`**: Added `healthCheck()` method that verifies PostgreSQL connectivity, Redis connectivity, connection pool health, database disk size, replication lag, and query performance metrics
- **`/health` endpoint**: Now calls `db.healthCheck()` and returns full health status with HTTP 503 for unhealthy state
- **Bugfix**: Removed duplicate `/metrics` handler that was incorrectly nested inside `/metrics/queries`
- **Tests**: 7 unit tests covering healthy, unhealthy, degraded, replication, disk size, and graceful failure paths

## Health Check Response

```json
{
  "status": "healthy",
  "postgres": { "status": "connected", "latencyMs": 2.34, "poolStats": { "total": 5, "idle": 3, "waiting": 0, "max": 20 } },
  "redis": { "status": "connected", "latencyMs": 0.51 },
  "database": { "sizeBytes": 1048576, "sizeFormatted": "1 MB" },
  "replication": { "isReplica": false, "lagMs": null },
  "queryMetrics": { "totalQueries": 42, "slowQueries": 0, "averageDurationMs": 12.5 },
  "timestamp": "2026-05-28T01:30:00.000Z"
}
```

## Testing

- [x] All 7 new tests pass
- [x] No new TypeScript errors
- [x] Healthy, degraded, and unhealthy statuses verified

Closes #28