### PR TITLE
feat(api): add API key rate limits and consistent resolver error handling

### DIFF
--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -77,24 +77,127 @@ class ApiServer {
 
     this.app.use(compression());
 
-    const limiter = rateLimit({
-      windowMs: 60 * 1000,
-      max: 1000,
+    // ── Rate limiting ─────────────────────────────────────────────────────────
+    //
+    // Three tiers, applied in order. The first limiter that matches a request
+    // key is the one that counts against it.
+    //
+    // Tier 1 – API key clients  (x-api-key header present)
+    //   Lower ceiling than JWT users because API keys are long-lived credentials
+    //   that may be shared or scripted. Keyed on the raw API key value so each
+    //   key has its own independent bucket.
+    //
+    // Tier 2 – Authenticated JWT users  (Bearer token present and valid)
+    //   Higher ceiling than anonymous callers. Keyed on user ID so the limit
+    //   follows the user regardless of IP.
+    //
+    // Tier 3 – Anonymous / IP fallback
+    //   Lowest ceiling. Keyed on IP address.
+
+    const API_KEY_WINDOW_MS   = parseInt(process.env.RATE_LIMIT_API_KEY_WINDOW_MS   || '60000',  10);
+    const API_KEY_MAX         = parseInt(process.env.RATE_LIMIT_API_KEY_MAX         || '300',    10);
+    const JWT_USER_WINDOW_MS  = parseInt(process.env.RATE_LIMIT_JWT_USER_WINDOW_MS  || '60000',  10);
+    const JWT_USER_MAX        = parseInt(process.env.RATE_LIMIT_JWT_USER_MAX        || '1000',   10);
+    const ANON_WINDOW_MS      = parseInt(process.env.RATE_LIMIT_ANON_WINDOW_MS      || '60000',  10);
+    const ANON_MAX            = parseInt(process.env.RATE_LIMIT_ANON_MAX            || '100',    10);
+
+    // Tier 1 – API key limiter
+    const apiKeyLimiter = rateLimit({
+      windowMs: API_KEY_WINDOW_MS,
+      max: API_KEY_MAX,
       standardHeaders: true,
       legacyHeaders: false,
-      message: { error: 'Too many requests from this IP, please try again later.' },
+      // Skip requests that are NOT using an API key — let the next limiter handle them
+      skip: (req) => {
+        const apiKey = req.headers['x-api-key'] as string | undefined;
+        return !apiKey || !authService.validateApiKey(apiKey);
+      },
+      keyGenerator: (req) => {
+        // Key on the API key itself so each issued key has its own bucket
+        return `apikey:${req.headers['x-api-key']}`;
+      },
+      message: {
+        error: 'API key rate limit exceeded. Please reduce your request rate or contact support to increase your quota.',
+      },
+      handler: (req, res, next, options) => {
+        this.logger.warn('API key rate limit exceeded', {
+          apiKey: (req.headers['x-api-key'] as string)?.substring(0, 12) + '…',
+          ip: req.ip,
+          limit: options.max,
+          windowMs: options.windowMs,
+        });
+        res.status(429).json(options.message);
+      },
+    });
+
+    // Tier 2 – JWT user limiter
+    const jwtUserLimiter = rateLimit({
+      windowMs: JWT_USER_WINDOW_MS,
+      max: JWT_USER_MAX,
+      standardHeaders: true,
+      legacyHeaders: false,
+      // Skip API key requests (already handled above) and anonymous requests
+      skip: (req) => {
+        const apiKey = req.headers['x-api-key'] as string | undefined;
+        if (apiKey && authService.validateApiKey(apiKey)) return true;
+        const token = authService.extractToken(req.headers.authorization);
+        if (!token) return true;
+        return !authService.verifyToken(token);
+      },
       keyGenerator: (req) => {
         const token = authService.extractToken(req.headers.authorization);
         if (token) {
           const payload = authService.verifyToken(token);
-          if (payload) {
-            return `user:${payload.userId}`;
-          }
+          if (payload) return `user:${payload.userId}`;
         }
         return req.ip || req.socket.remoteAddress || 'unknown';
       },
+      message: {
+        error: 'Too many requests. Please slow down and try again later.',
+      },
+      handler: (req, res, next, options) => {
+        const token = authService.extractToken(req.headers.authorization);
+        const payload = token ? authService.verifyToken(token) : null;
+        this.logger.warn('JWT user rate limit exceeded', {
+          userId: payload?.userId ?? 'unknown',
+          ip: req.ip,
+          limit: options.max,
+          windowMs: options.windowMs,
+        });
+        res.status(429).json(options.message);
+      },
     });
-    this.app.use('/graphql', limiter);
+
+    // Tier 3 – Anonymous / IP fallback limiter
+    const anonLimiter = rateLimit({
+      windowMs: ANON_WINDOW_MS,
+      max: ANON_MAX,
+      standardHeaders: true,
+      legacyHeaders: false,
+      // Skip authenticated requests — they are handled by the tiers above
+      skip: (req) => {
+        const apiKey = req.headers['x-api-key'] as string | undefined;
+        if (apiKey && authService.validateApiKey(apiKey)) return true;
+        const token = authService.extractToken(req.headers.authorization);
+        if (token && authService.verifyToken(token)) return true;
+        return false;
+      },
+      keyGenerator: (req) => req.ip || req.socket.remoteAddress || 'unknown',
+      message: {
+        error: 'Too many requests from this IP, please try again later.',
+      },
+      handler: (req, res, next, options) => {
+        this.logger.warn('Anonymous rate limit exceeded', {
+          ip: req.ip,
+          limit: options.max,
+          windowMs: options.windowMs,
+        });
+        res.status(429).json(options.message);
+      },
+    });
+
+    // Apply all three limiters to the GraphQL endpoint
+    this.app.use('/graphql', apiKeyLimiter, jwtUserLimiter, anonLimiter);
 
     this.app.get('/health', async (_req, res) => {
       try {

--- a/packages/api/src/resolvers/analytics.ts
+++ b/packages/api/src/resolvers/analytics.ts
@@ -3,6 +3,7 @@ import { db, CACHE_TTL } from '../database/connection';
 import { buildCacheKey, cachedQuery } from '../database/cached-query';
 import { getStatsSummary } from '../services/stats-service';
 import { ValidationService } from '../services/validation';
+import { withResolverLogging } from '../utils/resolver-error';
 
 const NETWORK_METRICS_CACHE_TTL_SECONDS = Number(
   process.env.NETWORK_METRICS_CACHE_TTL_SECONDS ?? 30
@@ -10,14 +11,16 @@ const NETWORK_METRICS_CACHE_TTL_SECONDS = Number(
 
 export const analyticsResolvers = {
   Query: {
-    networkMetrics: async (
-      parent: unknown,
-      args: {
-        timeRange?: { startTime?: string; endTime?: string };
-      },
-      _context: unknown,
-      _info: GraphQLResolveInfo
-    ) => {
+    networkMetrics: withResolverLogging(
+      'Query.networkMetrics',
+      async (
+        parent: unknown,
+        args: {
+          timeRange?: { startTime?: string; endTime?: string };
+        },
+        _context: unknown,
+        _info: GraphQLResolveInfo
+      ) => {
       if (args.timeRange) {
         ValidationService.validateTimeRange(args.timeRange);
       }
@@ -63,191 +66,200 @@ export const analyticsResolvers = {
         averageFee: parseFloat(metric.average_fee),
         successRate: parseFloat(metric.success_rate),
       }));
-    },
+    }),
 
-    assetMetrics: async (
-      parent: unknown,
-      args: {
-        pagination?: { first?: number; after?: string; last?: number; before?: string };
-        filter?: {
-          assetType?: string;
-          assetCode?: string;
-          assetIssuer?: string;
-        };
-        timeRange?: { startTime?: string; endTime?: string };
-      },
-      _context: unknown,
-      _info: GraphQLResolveInfo
-    ) => {
-      if (args.pagination) {
-        ValidationService.validatePagination(args.pagination);
-      }
-      if (args.filter) {
-        ValidationService.validateAssetFilter(args.filter);
-      }
-      if (args.timeRange) {
-        ValidationService.validateTimeRange(args.timeRange);
-      }
-
-      const { first = 50 } = args.pagination || {};
-      const { assetType, assetCode, assetIssuer } = args.filter || {};
-      const { startTime, endTime } = args.timeRange || {};
-
-      const cacheKey = `assetMetrics:${assetType || 'all'}:${assetCode || 'all'}:${assetIssuer || 'all'}:${first}`;
-
-      // Try cache first
-      const cached = await db.cacheGet(cacheKey);
-      if (cached) {
-        return cached;
-      }
-
-      let whereClause = 'WHERE 1=1';
-      const params: unknown[] = [];
-      let paramIndex = 1;
-
-      if (assetType) {
-        whereClause += ` AND a.asset_type = $${paramIndex++}`;
-        params.push(assetType);
-      }
-      if (assetCode) {
-        whereClause += ` AND a.asset_code = $${paramIndex++}`;
-        params.push(assetCode);
-      }
-      if (assetIssuer) {
-        whereClause += ` AND a.asset_issuer = $${paramIndex++}`;
-        params.push(assetIssuer);
-      }
-      if (startTime) {
-        whereClause += ` AND am.timestamp >= $${paramIndex++}`;
-        params.push(startTime);
-      }
-      if (endTime) {
-        whereClause += ` AND am.timestamp <= $${paramIndex++}`;
-        params.push(endTime);
-      }
-
-      const query = `
-        SELECT DISTINCT ON (a.id)
-          a.asset_type, a.asset_code, a.asset_issuer, a.native,
-          am.volume_24h, am.volume_7d, am.volume_30d,
-          am.trades_24h, am.trades_7d, am.trades_30d,
-          am.price_change_24h, am.market_cap, am.holders
-        FROM assets a
-        LEFT JOIN LATERAL (
-          SELECT volume_24h, volume_7d, volume_30d, trades_24h, trades_7d, trades_30d,
-                 price_change_24h, market_cap, holders
-          FROM asset_metrics
-          WHERE asset_id = a.id
-          ORDER BY timestamp DESC
-          LIMIT 1
-        ) am ON TRUE
-        ${whereClause}
-        ORDER BY a.id
-        LIMIT $${paramIndex}
-      `;
-      params.push(first);
-
-      const assets = await db.query(query, params);
-
-      const result = assets.map((asset) => ({
-        asset: {
-          assetType: asset.asset_type,
-          assetCode: asset.asset_code,
-          assetIssuer: asset.asset_issuer,
-          native: asset.native,
+    assetMetrics: withResolverLogging(
+      'Query.assetMetrics',
+      async (
+        parent: unknown,
+        args: {
+          pagination?: { first?: number; after?: string; last?: number; before?: string };
+          filter?: {
+            assetType?: string;
+            assetCode?: string;
+            assetIssuer?: string;
+          };
+          timeRange?: { startTime?: string; endTime?: string };
         },
-        volume24h: asset.volume_24h,
-        volume7d: asset.volume_7d,
-        volume30d: asset.volume_30d,
-        trades24h: asset.trades_24h,
-        trades7d: asset.trades_7d,
-        trades30d: asset.trades_30d,
-        priceChange24h: parseFloat(asset.price_change_24h ?? '0'),
-        marketCap: asset.market_cap,
-        holders: asset.holders,
-      }));
+        _context: unknown,
+        _info: GraphQLResolveInfo
+      ) => {
+        if (args.pagination) {
+          ValidationService.validatePagination(args.pagination);
+        }
+        if (args.filter) {
+          ValidationService.validateAssetFilter(args.filter);
+        }
+        if (args.timeRange) {
+          ValidationService.validateTimeRange(args.timeRange);
+        }
 
-      // Cache the result
-      await db.cacheSet(cacheKey, result, CACHE_TTL.ASSET_DATA);
-      return result;
-    },
+        const { first = 50 } = args.pagination || {};
+        const { assetType, assetCode, assetIssuer } = args.filter || {};
+        const { startTime, endTime } = args.timeRange || {};
 
-    accountMetrics: async (
-      parent: unknown,
-      args: {
-        accountId: string;
-        timeRange?: { startTime?: string; endTime?: string };
-      },
-      _context: unknown,
-      _info: GraphQLResolveInfo
-    ) => {
-      ValidationService.validateAddress(args.accountId);
-      if (args.timeRange) {
-        ValidationService.validateTimeRange(args.timeRange);
+        const cacheKey = `assetMetrics:${assetType || 'all'}:${assetCode || 'all'}:${assetIssuer || 'all'}:${first}`;
+
+        // Try cache first
+        const cached = await db.cacheGet(cacheKey);
+        if (cached) {
+          return cached;
+        }
+
+        let whereClause = 'WHERE 1=1';
+        const params: unknown[] = [];
+        let paramIndex = 1;
+
+        if (assetType) {
+          whereClause += ` AND a.asset_type = $${paramIndex++}`;
+          params.push(assetType);
+        }
+        if (assetCode) {
+          whereClause += ` AND a.asset_code = $${paramIndex++}`;
+          params.push(assetCode);
+        }
+        if (assetIssuer) {
+          whereClause += ` AND a.asset_issuer = $${paramIndex++}`;
+          params.push(assetIssuer);
+        }
+        if (startTime) {
+          whereClause += ` AND am.timestamp >= $${paramIndex++}`;
+          params.push(startTime);
+        }
+        if (endTime) {
+          whereClause += ` AND am.timestamp <= $${paramIndex++}`;
+          params.push(endTime);
+        }
+
+        const query = `
+          SELECT DISTINCT ON (a.id)
+            a.asset_type, a.asset_code, a.asset_issuer, a.native,
+            am.volume_24h, am.volume_7d, am.volume_30d,
+            am.trades_24h, am.trades_7d, am.trades_30d,
+            am.price_change_24h, am.market_cap, am.holders
+          FROM assets a
+          LEFT JOIN LATERAL (
+            SELECT volume_24h, volume_7d, volume_30d, trades_24h, trades_7d, trades_30d,
+                   price_change_24h, market_cap, holders
+            FROM asset_metrics
+            WHERE asset_id = a.id
+            ORDER BY timestamp DESC
+            LIMIT 1
+          ) am ON TRUE
+          ${whereClause}
+          ORDER BY a.id
+          LIMIT $${paramIndex}
+        `;
+        params.push(first);
+
+        const assets = await db.query(query, params);
+
+        const result = assets.map((asset) => ({
+          asset: {
+            assetType: asset.asset_type,
+            assetCode: asset.asset_code,
+            assetIssuer: asset.asset_issuer,
+            native: asset.native,
+          },
+          volume24h: asset.volume_24h,
+          volume7d: asset.volume_7d,
+          volume30d: asset.volume_30d,
+          trades24h: asset.trades_24h,
+          trades7d: asset.trades_7d,
+          trades30d: asset.trades_30d,
+          priceChange24h: parseFloat(asset.price_change_24h ?? '0'),
+          marketCap: asset.market_cap,
+          holders: asset.holders,
+        }));
+
+        // Cache the result
+        await db.cacheSet(cacheKey, result, CACHE_TTL.ASSET_DATA);
+        return result;
       }
+    ),
 
-      const { accountId } = args;
-      const { startTime, endTime } = args.timeRange || {};
+    accountMetrics: withResolverLogging(
+      'Query.accountMetrics',
+      async (
+        parent: unknown,
+        args: {
+          accountId: string;
+          timeRange?: { startTime?: string; endTime?: string };
+        },
+        _context: unknown,
+        _info: GraphQLResolveInfo
+      ) => {
+        ValidationService.validateAddress(args.accountId);
+        if (args.timeRange) {
+          ValidationService.validateTimeRange(args.timeRange);
+        }
 
-      const cacheKey = `accountMetrics:${accountId}:${startTime || 'all'}:${endTime || 'all'}`;
+        const { accountId } = args;
+        const { startTime, endTime } = args.timeRange || {};
 
-      // Try cache first
-      const cached = await db.cacheGet(cacheKey);
-      if (cached) {
-        return cached;
+        const cacheKey = `accountMetrics:${accountId}:${startTime || 'all'}:${endTime || 'all'}`;
+
+        // Try cache first
+        const cached = await db.cacheGet(cacheKey);
+        if (cached) {
+          return cached;
+        }
+
+        let whereClause = 'WHERE account_id = $1';
+        const params: unknown[] = [accountId];
+        let paramIndex = 2;
+
+        if (startTime) {
+          whereClause += ` AND timestamp >= $${paramIndex++}`;
+          params.push(startTime);
+        }
+        if (endTime) {
+          whereClause += ` AND timestamp <= $${paramIndex++}`;
+          params.push(endTime);
+        }
+
+        const metrics = await db.query(
+          `
+          SELECT 
+            account_id, timestamp, balance_native, total_balance_usd,
+            transaction_count_24h, transaction_count_7d, transaction_count_30d,
+            first_transaction, last_transaction, is_active, trustlines, signers
+          FROM account_metrics 
+          ${whereClause}
+          ORDER BY timestamp DESC
+          LIMIT 100
+        `,
+          params
+        );
+
+        const result = metrics.map((metric) => ({
+          accountId: metric.account_id,
+          balanceNative: metric.balance_native,
+          totalBalanceUsd: metric.total_balance_usd,
+          transactionCount24h: metric.transaction_count_24h,
+          transactionCount7d: metric.transaction_count_7d,
+          transactionCount30d: metric.transaction_count_30d,
+          firstTransaction: metric.first_transaction,
+          lastTransaction: metric.last_transaction,
+          isActive: metric.is_active,
+          trustlines: metric.trustlines,
+          signers: metric.signers,
+        }));
+
+        // Cache the result
+        await db.cacheSet(cacheKey, result, CACHE_TTL.ACCOUNT_STATS);
+        return result;
       }
+    ),
 
-      let whereClause = 'WHERE account_id = $1';
-      const params: unknown[] = [accountId];
-      let paramIndex = 2;
-
-      if (startTime) {
-        whereClause += ` AND timestamp >= $${paramIndex++}`;
-        params.push(startTime);
-      }
-      if (endTime) {
-        whereClause += ` AND timestamp <= $${paramIndex++}`;
-        params.push(endTime);
-      }
-
-      const metrics = await db.query(
-        `
-        SELECT 
-          account_id, timestamp, balance_native, total_balance_usd,
-          transaction_count_24h, transaction_count_7d, transaction_count_30d,
-          first_transaction, last_transaction, is_active, trustlines, signers
-        FROM account_metrics 
-        ${whereClause}
-        ORDER BY timestamp DESC
-        LIMIT 100
-      `,
-        params
-      );
-
-      const result = metrics.map((metric) => ({
-        accountId: metric.account_id,
-        balanceNative: metric.balance_native,
-        totalBalanceUsd: metric.total_balance_usd,
-        transactionCount24h: metric.transaction_count_24h,
-        transactionCount7d: metric.transaction_count_7d,
-        transactionCount30d: metric.transaction_count_30d,
-        firstTransaction: metric.first_transaction,
-        lastTransaction: metric.last_transaction,
-        isActive: metric.is_active,
-        trustlines: metric.trustlines,
-        signers: metric.signers,
-      }));
-
-      // Cache the result
-      await db.cacheSet(cacheKey, result, CACHE_TTL.ACCOUNT_STATS);
-      return result;
-    },
-
-    stats: async (
-      parent: unknown,
-      args: unknown,
-      _context: unknown,
-      _info: GraphQLResolveInfo
-    ) => getStatsSummary(),
+    stats: withResolverLogging(
+      'Query.stats',
+      async (
+        parent: unknown,
+        args: unknown,
+        _context: unknown,
+        _info: GraphQLResolveInfo
+      ) => getStatsSummary()
+    ),
   },
 };

--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -4,114 +4,130 @@ import { analyticsResolvers } from './analytics';
 import { pubsub, EVENTS } from '../pubsub';
 import { authService, User } from '../services/auth';
 import { db } from '../database/connection';
+import { withResolverLogging, AuthError, NotFoundError } from '../utils/resolver-error';
 
 export const resolvers = {
   Query: {
     ...ledgerResolvers.Query,
     ...transactionResolvers.Query,
     ...analyticsResolvers.Query,
-    me: async (_: any, __: any, context: any) => {
-      if (!context.user) {
-        return null;
+    me: withResolverLogging(
+      'Query.me',
+      async (_: any, __: any, context: any) => {
+        if (!context.user) {
+          return null;
+        }
+        return context.user;
       }
-      return context.user;
-    },
+    ),
   },
   Mutation: {
-    register: async (_: any, args: { input: { email: string; password: string; name: string } }, context: any) => {
-      const { email, password, name } = args.input;
+    register: withResolverLogging(
+      'Mutation.register',
+      async (_: any, args: { input: { email: string; password: string; name: string } }, context: any) => {
+        const { email, password, name } = args.input;
 
-      const existing = await db.queryOne('SELECT id FROM users WHERE email = $1', [email]);
-      if (existing) {
-        throw new Error('User with this email already exists');
-      }
+        const existing = await db.queryOne('SELECT id FROM users WHERE email = $1', [email]);
+        if (existing) {
+          throw new NotFoundError('User with this email already exists');
+        }
 
-      const hashedPassword = await authService.hashPassword(password);
-      const apiKey = authService.generateApiKey();
+        const hashedPassword = await authService.hashPassword(password);
+        const apiKey = authService.generateApiKey();
 
-      const user = await db.queryOne(
-        `INSERT INTO users (email, password_hash, name, role, api_key, created_at)
-         VALUES ($1, $2, $3, $4, $5, NOW())
-         RETURNING id, email, name, role, api_key, created_at`,
-        [email, hashedPassword, name, 'viewer', apiKey]
-      );
+        const user = await db.queryOne(
+          `INSERT INTO users (email, password_hash, name, role, api_key, created_at)
+           VALUES ($1, $2, $3, $4, $5, NOW())
+           RETURNING id, email, name, role, api_key, created_at`,
+          [email, hashedPassword, name, 'viewer', apiKey]
+        );
 
-      const token = authService.generateToken({
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        role: user.role,
-        createdAt: user.created_at,
-      });
-
-      return {
-        user: {
+        const token = authService.generateToken({
           id: user.id,
           email: user.email,
           name: user.name,
           role: user.role,
           createdAt: user.created_at,
-        },
-        token,
-      };
-    },
-    login: async (_: any, args: { input: { email: string; password: string } }, context: any) => {
-      const { email, password } = args.input;
+        });
 
-      const user = await db.queryOne(
-        'SELECT id, email, password_hash, name, role, api_key, created_at FROM users WHERE email = $1',
-        [email]
-      );
-
-      if (!user) {
-        throw new Error('Invalid email or password');
+        return {
+          user: {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            role: user.role,
+            createdAt: user.created_at,
+          },
+          token,
+        };
       }
+    ),
+    login: withResolverLogging(
+      'Mutation.login',
+      async (_: any, args: { input: { email: string; password: string } }, context: any) => {
+        const { email, password } = args.input;
 
-      const valid = await authService.verifyPassword(password, user.password_hash);
-      if (!valid) {
-        throw new Error('Invalid email or password');
-      }
+        const user = await db.queryOne(
+          'SELECT id, email, password_hash, name, role, api_key, created_at FROM users WHERE email = $1',
+          [email]
+        );
 
-      const token = authService.generateToken({
-        id: user.id,
-        email: user.email,
-        name: user.name,
-        role: user.role,
-        createdAt: user.created_at,
-      });
+        if (!user) {
+          throw new AuthError('Invalid email or password');
+        }
 
-      return {
-        user: {
+        const valid = await authService.verifyPassword(password, user.password_hash);
+        if (!valid) {
+          throw new AuthError('Invalid email or password');
+        }
+
+        const token = authService.generateToken({
           id: user.id,
           email: user.email,
           name: user.name,
           role: user.role,
           createdAt: user.created_at,
-        },
-        token,
-      };
-    },
-    generateApiKey: async (_: any, __: any, context: any) => {
-      if (!context.user) {
-        throw new Error('Authentication required');
+        });
+
+        return {
+          user: {
+            id: user.id,
+            email: user.email,
+            name: user.name,
+            role: user.role,
+            createdAt: user.created_at,
+          },
+          token,
+        };
       }
+    ),
+    generateApiKey: withResolverLogging(
+      'Mutation.generateApiKey',
+      async (_: any, __: any, context: any) => {
+        if (!context.user) {
+          throw new AuthError();
+        }
 
-      const apiKey = authService.generateApiKey();
-      await db.query('UPDATE users SET api_key = $1 WHERE id = $2', [apiKey, context.user.id]);
+        const apiKey = authService.generateApiKey();
+        await db.query('UPDATE users SET api_key = $1 WHERE id = $2', [apiKey, context.user.id]);
 
-      return {
-        apiKey,
-        user: context.user,
-      };
-    },
-    revokeApiKey: async (_: any, __: any, context: any) => {
-      if (!context.user) {
-        throw new Error('Authentication required');
+        return {
+          apiKey,
+          user: context.user,
+        };
       }
+    ),
+    revokeApiKey: withResolverLogging(
+      'Mutation.revokeApiKey',
+      async (_: any, __: any, context: any) => {
+        if (!context.user) {
+          throw new AuthError();
+        }
 
-      await db.query('UPDATE users SET api_key = NULL WHERE id = $1', [context.user.id]);
-      return true;
-    },
+        await db.query('UPDATE users SET api_key = NULL WHERE id = $1', [context.user.id]);
+        return true;
+      }
+    ),
   },
   Subscription: {
     ledgerAdded: {

--- a/packages/api/src/resolvers/ledgers.ts
+++ b/packages/api/src/resolvers/ledgers.ts
@@ -4,10 +4,13 @@ import { Connection, Edge, PageInfo } from '@stellar-analytics/shared';
 import { mapLedger } from '../utils/mappers';
 import type { ApiLoaders } from '../loaders';
 import { ValidationService } from '../services/validation';
+import { withResolverLogging, NotFoundError } from '../utils/resolver-error';
 
 export const ledgerResolvers = {
   Query: {
-    ledgers: async (
+    ledgers: withResolverLogging(
+      'Query.ledgers',
+      async (
       parent: any,
       args: {
         pagination?: { first?: number; after?: string; last?: number; before?: string };
@@ -111,41 +114,46 @@ export const ledgerResolvers = {
       // Cache the result
       await db.cacheSet(cacheKey, result, CACHE_TTL.LEDGER_DATA);
       return result;
-    },
+    }),
 
-    ledger: async (
-      parent: unknown,
-      args: { sequence: number },
-      context: { loaders: ApiLoaders },
-      _info: GraphQLResolveInfo
-    ) => {
-      const cacheKey = `ledger:${args.sequence}`;
+    ledger: withResolverLogging(
+      'Query.ledger',
+      async (
+        parent: unknown,
+        args: { sequence: number },
+        context: { loaders: ApiLoaders },
+        _info: GraphQLResolveInfo
+      ) => {
+        const cacheKey = `ledger:${args.sequence}`;
 
-      // Try cache first
-      const cached = await db.cacheGet(cacheKey);
-      if (cached) {
-        return cached;
+        // Try cache first
+        const cached = await db.cacheGet(cacheKey);
+        if (cached) {
+          return cached;
+        }
+
+        const ledgerData = await db.queryOne(
+          `SELECT 
+            id, sequence, successful_transaction_count, failed_transaction_count,
+            operation_count, tx_set_operation_count, closed_at, total_coins,
+            fee_pool, base_fee_in_stroops, base_reserve_in_stroops,
+            max_tx_set_size, protocol_version, header_xdr, created_at, updated_at
+          FROM ledgers WHERE sequence = $1`,
+          [args.sequence]
+        );
+
+        if (!ledgerData) {
+          throw new NotFoundError('Ledger', args.sequence);
+        }
+
+        const result = {
+          ...mapLedger(ledgerData),
+        };
+
+        // Cache the result
+        await db.cacheSet(cacheKey, result, CACHE_TTL.LEDGER_DATA);
+        return result;
       }
-
-      const ledgerData = await db.queryOne(
-        `SELECT 
-          id, sequence, successful_transaction_count, failed_transaction_count,
-          operation_count, tx_set_operation_count, closed_at, total_coins,
-          fee_pool, base_fee_in_stroops, base_reserve_in_stroops,
-          max_tx_set_size, protocol_version, header_xdr, created_at, updated_at
-        FROM ledgers WHERE sequence = $1`,
-        [args.sequence]
-      );
-
-      if (!ledgerData) return null;
-
-      const result = {
-        ...mapLedger(ledgerData)
-      };
-
-      // Cache the result
-      await db.cacheSet(cacheKey, result, CACHE_TTL.LEDGER_DATA);
-      return result;
-    },
+    ),
   },
 };

--- a/packages/api/src/resolvers/transactions.ts
+++ b/packages/api/src/resolvers/transactions.ts
@@ -3,6 +3,7 @@ import { db, CACHE_TTL } from '../database/connection';
 import { mapOperation, mapTransaction } from '../utils/mappers';
 import type { ApiLoaders } from '../loaders';
 import { ValidationService } from '../services/validation';
+import { withResolverLogging, NotFoundError } from '../utils/resolver-error';
 
 export interface ResolverContext {
   loaders: ApiLoaders;
@@ -10,22 +11,24 @@ export interface ResolverContext {
 
 export const transactionResolvers = {
   Query: {
-    transactions: async (
-      parent: unknown,
-      args: {
-        pagination?: { first?: number; after?: string; last?: number; before?: string };
-        timeRange?: { startTime?: string; endTime?: string };
-        filter?: {
-          successful?: boolean;
-          minFee?: number;
-          maxFee?: number;
-          hasMemo?: boolean;
-          memoType?: string;
-        };
-      },
-      context: ResolverContext,
-      _info: GraphQLResolveInfo
-    ) => {
+    transactions: withResolverLogging(
+      'Query.transactions',
+      async (
+        parent: unknown,
+        args: {
+          pagination?: { first?: number; after?: string; last?: number; before?: string };
+          timeRange?: { startTime?: string; endTime?: string };
+          filter?: {
+            successful?: boolean;
+            minFee?: number;
+            maxFee?: number;
+            hasMemo?: boolean;
+            memoType?: string;
+          };
+        },
+        context: ResolverContext,
+        _info: GraphQLResolveInfo
+      ) => {
       const { first = 20, after, before } = args.pagination || {};
 
       // Issue #31 – Validate pagination with comprehensive checks
@@ -145,73 +148,81 @@ export const transactionResolvers = {
       await db.cacheSet(cacheKey, result, CACHE_TTL.LEDGER_DATA);
       await db.incrementCacheMetric('transactions');
       return result;
-    },
+    }),
 
-    transaction: async (
-      parent: unknown,
-      args: { hash: string },
-      context: ResolverContext,
-      _info: GraphQLResolveInfo
-    ) => {
-      const cacheKey = `transaction:${args.hash}`;
+    transaction: withResolverLogging(
+      'Query.transaction',
+      async (
+        parent: unknown,
+        args: { hash: string },
+        context: ResolverContext,
+        _info: GraphQLResolveInfo
+      ) => {
+        const cacheKey = `transaction:${args.hash}`;
 
-      // Try cache first
-      const cached = await db.cacheGet(cacheKey);
-      if (cached) {
+        // Try cache first
+        const cached = await db.cacheGet(cacheKey);
+        if (cached) {
+          await db.incrementCacheMetric('transaction');
+          return cached;
+        }
+
+        const transaction = await db.queryOne(
+          `SELECT 
+            id, paging_token, successful, hash, ledger_sequence, created_at,
+            source_account, source_account_sequence, fee_account, fee_charged,
+            max_fee, operation_count, envelope_xdr, result_xdr, result_meta_xdr,
+            fee_meta_xdr, memo_type, memo, signatures, valid_after, valid_before,
+            fee_bump_transaction, inner_transaction_hash, inner_transaction_signatures
+          FROM transactions WHERE hash = $1`,
+          [args.hash]
+        );
+
+        if (!transaction) {
+          throw new NotFoundError('Transaction', args.hash);
+        }
+
+        const result = {
+          ...transaction,
+          createdAt: transaction.created_at,
+          sourceAccount: transaction.source_account,
+          sourceAccountSequence: transaction.source_account_sequence,
+          feeAccount: transaction.fee_account,
+          feeCharged: transaction.fee_charged,
+          maxFee: transaction.max_fee,
+          operationCount: transaction.operation_count,
+          envelopeXdr: transaction.envelope_xdr,
+          resultXdr: transaction.result_xdr,
+          resultMetaXdr: transaction.result_meta_xdr,
+          feeMetaXdr: transaction.fee_meta_xdr,
+          memoType: transaction.memo_type,
+          validAfter: transaction.valid_after,
+          validBefore: transaction.valid_before,
+          feeBumpTransaction: transaction.fee_bump_transaction,
+          innerTransactionHash: transaction.inner_transaction_hash,
+          innerTransactionSignatures: transaction.inner_transaction_signatures,
+        };
+
+        // Cache the result
+        await db.cacheSet(cacheKey, result, CACHE_TTL.LEDGER_DATA);
         await db.incrementCacheMetric('transaction');
-        return cached;
+        return result;
       }
-
-      const transaction = await db.queryOne(
-        `SELECT 
-          id, paging_token, successful, hash, ledger_sequence, created_at,
-          source_account, source_account_sequence, fee_account, fee_charged,
-          max_fee, operation_count, envelope_xdr, result_xdr, result_meta_xdr,
-          fee_meta_xdr, memo_type, memo, signatures, valid_after, valid_before,
-          fee_bump_transaction, inner_transaction_hash, inner_transaction_signatures
-        FROM transactions WHERE hash = $1`,
-        [args.hash]
-      );
-
-      if (!transaction) return null;
-
-      const result = {
-        ...transaction,
-        createdAt: transaction.created_at,
-        sourceAccount: transaction.source_account,
-        sourceAccountSequence: transaction.source_account_sequence,
-        feeAccount: transaction.fee_account,
-        feeCharged: transaction.fee_charged,
-        maxFee: transaction.max_fee,
-        operationCount: transaction.operation_count,
-        envelopeXdr: transaction.envelope_xdr,
-        resultXdr: transaction.result_xdr,
-        resultMetaXdr: transaction.result_meta_xdr,
-        feeMetaXdr: transaction.fee_meta_xdr,
-        memoType: transaction.memo_type,
-        validAfter: transaction.valid_after,
-        validBefore: transaction.valid_before,
-        feeBumpTransaction: transaction.fee_bump_transaction,
-        innerTransactionHash: transaction.inner_transaction_hash,
-        innerTransactionSignatures: transaction.inner_transaction_signatures,
-      };
-
-      // Cache the result
-      await db.cacheSet(cacheKey, result, CACHE_TTL.LEDGER_DATA);
-      await db.incrementCacheMetric('transaction');
-      return result;
-    },
+    ),
   },
 
   Transaction: {
-    operations: async (
-      parent: { hash: string },
-      _args: unknown,
-      context: ResolverContext,
-      _info: GraphQLResolveInfo
-    ) => {
-      const operations = await context.loaders.transactionOperationsLoader.load(parent.hash);
-      return operations.map((op) => mapOperation(op));
-    },
+    operations: withResolverLogging(
+      'Transaction.operations',
+      async (
+        parent: { hash: string },
+        _args: unknown,
+        context: ResolverContext,
+        _info: GraphQLResolveInfo
+      ) => {
+        const operations = await context.loaders.transactionOperationsLoader.load(parent.hash);
+        return operations.map((op) => mapOperation(op));
+      }
+    ),
   },
 };

--- a/packages/api/src/utils/resolver-error.ts
+++ b/packages/api/src/utils/resolver-error.ts
@@ -1,0 +1,231 @@
+/**
+ * Consistent error formatting and logging utilities for GraphQL resolvers.
+ *
+ * Usage:
+ *   import { withResolverLogging, ResolverError, NotFoundError, AuthError } from '../utils/resolver-error';
+ *
+ *   myResolver: withResolverLogging('Query.myResolver', async (parent, args, context) => {
+ *     // resolver body — throw ResolverError subclasses for known error cases
+ *   }),
+ */
+
+import { GraphQLError } from 'graphql';
+import type winston from 'winston';
+
+// ── Error codes ───────────────────────────────────────────────────────────────
+
+export const ErrorCode = {
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+  NOT_FOUND: 'NOT_FOUND',
+  UNAUTHENTICATED: 'UNAUTHENTICATED',
+  FORBIDDEN: 'FORBIDDEN',
+  VALIDATION_ERROR: 'VALIDATION_ERROR',
+  BAD_USER_INPUT: 'BAD_USER_INPUT',
+  RATE_LIMITED: 'RATE_LIMITED',
+} as const;
+
+export type ErrorCode = (typeof ErrorCode)[keyof typeof ErrorCode];
+
+// ── Typed error classes ───────────────────────────────────────────────────────
+
+/**
+ * Base class for all resolver-level errors.
+ * Extends GraphQLError so Apollo Server serialises it correctly.
+ */
+export class ResolverError extends GraphQLError {
+  constructor(
+    message: string,
+    code: ErrorCode = ErrorCode.INTERNAL_ERROR,
+    extensions?: Record<string, unknown>
+  ) {
+    super(message, {
+      extensions: {
+        code,
+        timestamp: new Date().toISOString(),
+        ...extensions,
+      },
+    });
+    this.name = 'ResolverError';
+  }
+}
+
+/** Resource could not be found (maps to NOT_FOUND). */
+export class NotFoundError extends ResolverError {
+  constructor(resource: string, identifier?: string | number) {
+    const detail = identifier !== undefined ? ` (${identifier})` : '';
+    super(`${resource}${detail} not found`, ErrorCode.NOT_FOUND);
+    this.name = 'NotFoundError';
+  }
+}
+
+/** Request requires authentication (maps to UNAUTHENTICATED). */
+export class AuthError extends ResolverError {
+  constructor(message = 'Authentication required') {
+    super(message, ErrorCode.UNAUTHENTICATED);
+    this.name = 'AuthError';
+  }
+}
+
+/** Authenticated user lacks permission (maps to FORBIDDEN). */
+export class ForbiddenError extends ResolverError {
+  constructor(message = 'You do not have permission to perform this action') {
+    super(message, ErrorCode.FORBIDDEN);
+    this.name = 'ForbiddenError';
+  }
+}
+
+/** Client supplied invalid input (maps to BAD_USER_INPUT). */
+export class BadInputError extends ResolverError {
+  constructor(message: string, field?: string) {
+    super(message, ErrorCode.BAD_USER_INPUT, field ? { field } : undefined);
+    this.name = 'BadInputError';
+  }
+}
+
+// ── Logging helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Classify an error for logging purposes.
+ * Known resolver errors are "expected" and logged at warn level.
+ * Everything else is an unexpected server error logged at error level.
+ */
+function classifyError(err: unknown): { level: 'warn' | 'error'; isOperational: boolean } {
+  if (err instanceof ResolverError) {
+    // Operational errors — expected, no stack trace needed
+    return { level: 'warn', isOperational: true };
+  }
+  if (err instanceof GraphQLError) {
+    // Validation / depth-limit errors from Apollo — expected
+    return { level: 'warn', isOperational: true };
+  }
+  // Unexpected errors (DB failures, programming errors, etc.)
+  return { level: 'error', isOperational: false };
+}
+
+/**
+ * Format an error into a structured log payload.
+ */
+function formatErrorPayload(
+  resolverName: string,
+  err: unknown,
+  args: unknown,
+  userId?: string
+): Record<string, unknown> {
+  const base: Record<string, unknown> = {
+    resolver: resolverName,
+    userId: userId ?? 'anonymous',
+    args: sanitiseArgs(args),
+  };
+
+  if (err instanceof GraphQLError) {
+    return {
+      ...base,
+      errorCode: err.extensions?.code ?? ErrorCode.INTERNAL_ERROR,
+      message: err.message,
+    };
+  }
+
+  if (err instanceof Error) {
+    return {
+      ...base,
+      errorCode: ErrorCode.INTERNAL_ERROR,
+      message: err.message,
+      // Only include stack for unexpected errors — stripped in production by log level
+      stack: err.stack,
+    };
+  }
+
+  return {
+    ...base,
+    errorCode: ErrorCode.INTERNAL_ERROR,
+    message: String(err),
+  };
+}
+
+/**
+ * Strip sensitive fields from resolver args before logging.
+ */
+function sanitiseArgs(args: unknown): unknown {
+  if (!args || typeof args !== 'object') return args;
+  const sensitive = new Set(['password', 'token', 'apiKey', 'api_key', 'secret']);
+  return Object.fromEntries(
+    Object.entries(args as Record<string, unknown>).map(([k, v]) => [
+      k,
+      sensitive.has(k) ? '[REDACTED]' : v,
+    ])
+  );
+}
+
+/**
+ * Re-throw an unknown error as a ResolverError so the client always receives
+ * a consistent GraphQL error shape. Internal details are hidden in production.
+ */
+function normaliseError(err: unknown): GraphQLError {
+  if (err instanceof GraphQLError) return err;
+
+  const isProduction = process.env.NODE_ENV === 'production';
+  const message = isProduction
+    ? 'An unexpected error occurred. Please try again later.'
+    : err instanceof Error
+    ? err.message
+    : String(err);
+
+  return new ResolverError(message, ErrorCode.INTERNAL_ERROR);
+}
+
+// ── withResolverLogging wrapper ───────────────────────────────────────────────
+
+type ResolverFn<TParent, TArgs, TContext, TReturn> = (
+  parent: TParent,
+  args: TArgs,
+  context: TContext,
+  info: any
+) => Promise<TReturn> | TReturn;
+
+/**
+ * Wraps a resolver function with:
+ * - Structured error logging (warn for operational, error for unexpected)
+ * - Consistent error normalisation (unknown errors → ResolverError)
+ * - Performance timing logged at debug level
+ *
+ * @param resolverName  Human-readable name, e.g. "Query.ledgers"
+ * @param fn            The resolver implementation
+ */
+export function withResolverLogging<TParent = any, TArgs = any, TContext extends { logger?: winston.Logger; user?: { id: string } | null } = any, TReturn = any>(
+  resolverName: string,
+  fn: ResolverFn<TParent, TArgs, TContext, TReturn>
+): ResolverFn<TParent, TArgs, TContext, TReturn> {
+  return async (parent, args, context, info) => {
+    const start = Date.now();
+    const userId = context.user?.id;
+
+    try {
+      const result = await fn(parent, args, context, info);
+
+      const duration = Date.now() - start;
+      context.logger?.debug('Resolver completed', {
+        resolver: resolverName,
+        userId: userId ?? 'anonymous',
+        durationMs: duration,
+      });
+
+      return result;
+    } catch (err: unknown) {
+      const duration = Date.now() - start;
+      const { level, isOperational } = classifyError(err);
+      const payload = formatErrorPayload(resolverName, err, args, userId);
+
+      if (level === 'error') {
+        context.logger?.error('Resolver unexpected error', { ...payload, durationMs: duration });
+      } else {
+        context.logger?.warn('Resolver operational error', { ...payload, durationMs: duration });
+      }
+
+      // Re-throw operational errors as-is (already GraphQLErrors with correct codes)
+      if (isOperational) throw err;
+
+      // Normalise unexpected errors so clients never see raw DB/system messages
+      throw normaliseError(err);
+    }
+  };
+}


### PR DESCRIPTION


closes #127 

closes #126 

Add three-tier rate limiting to the GraphQL endpoint and introduce a
shared error formatting and logging utility applied across all resolvers.

## Rate limiting (packages/api/src/index.ts)

Replace the single flat limiter with three independent tiers:

- Tier 1 — API key clients (x-api-key header): 300 req/min, keyed on
  the API key value so each issued key has its own bucket
- Tier 2 — JWT authenticated users: 1000 req/min, keyed on userId
- Tier 3 — Anonymous / IP fallback: 100 req/min, keyed on IP address

Each tier skips requests it does not own, making them mutually exclusive.
All limits are configurable via env vars (RATE_LIMIT_API_KEY_MAX,
RATE_LIMIT_JWT_USER_MAX, RATE_LIMIT_ANON_MAX and their _WINDOW_MS
counterparts). Every 429 response emits a structured Winston warn log.

## Resolver error handling (packages/api/src/utils/resolver-error.ts)

New shared utility providing:

- Typed error classes — ResolverError, NotFoundError, AuthError,
  ForbiddenError, BadInputError — all extend GraphQLError with a
  consistent extensions.code and extensions.timestamp
- withResolverLogging wrapper — structured warn logging for operational
  errors, error logging with stack traces for unexpected failures,
  automatic normalisation of raw errors in production, and sensitive
  arg redaction (password, token, apiKey, etc.)

Applied to every resolver in packages/api/src/resolvers/:
ledgers, transactions, analytics, and the auth mutations in index.ts.
Raw throw new Error() calls in auth mutations replaced with AuthError
and NotFoundError for consistent GraphQL error codes.
