### PR TITLE
feat: add Zod validation for GraphQL mutations and Login form (#124, …

### DIFF
--- a/packages/api/src/resolvers/index.ts
+++ b/packages/api/src/resolvers/index.ts
@@ -2,8 +2,9 @@ import { ledgerResolvers } from './ledgers';
 import { transactionResolvers } from './transactions';
 import { analyticsResolvers } from './analytics';
 import { pubsub, EVENTS } from '../pubsub';
-import { authService, User } from '../services/auth';
+import { authService } from '../services/auth';
 import { db } from '../database/connection';
+import { ValidationService } from '../services/validation';
 
 export const resolvers = {
   Query: {
@@ -18,8 +19,9 @@ export const resolvers = {
     },
   },
   Mutation: {
-    register: async (_: any, args: { input: { email: string; password: string; name: string } }, context: any) => {
-      const { email, password, name } = args.input;
+    register: async (_: any, args: { input: unknown }) => {
+      // Issue #125 – Validate mutation input with Zod before processing
+      const { email, password, name } = ValidationService.validateRegisterInput(args.input);
 
       const existing = await db.queryOne('SELECT id FROM users WHERE email = $1', [email]);
       if (existing) {
@@ -55,8 +57,9 @@ export const resolvers = {
         token,
       };
     },
-    login: async (_: any, args: { input: { email: string; password: string } }, context: any) => {
-      const { email, password } = args.input;
+    login: async (_: any, args: { input: unknown }) => {
+      // Issue #125 – Validate mutation input with Zod before processing
+      const { email, password } = ValidationService.validateLoginInput(args.input);
 
       const user = await db.queryOne(
         'SELECT id, email, password_hash, name, role, api_key, created_at FROM users WHERE email = $1',
@@ -92,6 +95,7 @@ export const resolvers = {
       };
     },
     generateApiKey: async (_: any, __: any, context: any) => {
+      // Issue #125 – Authentication guard (no user-supplied input to validate here)
       if (!context.user) {
         throw new Error('Authentication required');
       }
@@ -105,6 +109,7 @@ export const resolvers = {
       };
     },
     revokeApiKey: async (_: any, __: any, context: any) => {
+      // Issue #125 – Authentication guard (no user-supplied input to validate here)
       if (!context.user) {
         throw new Error('Authentication required');
       }

--- a/packages/api/src/services/validation.ts
+++ b/packages/api/src/services/validation.ts
@@ -2,9 +2,58 @@ import { GraphQLError } from 'graphql';
 import { z } from 'zod';
 
 const CursorSchema = z.string().min(1);
-const AddressSchema = z.string().min(1).regex(/^G[A-Z0-9]{55}$/);
-const HashSchema = z.string().min(1).regex(/^[a-fA-F0-9]{64}$/);
+const AddressSchema = z
+  .string()
+  .min(1)
+  .regex(/^G[A-Z0-9]{55}$/);
+const HashSchema = z
+  .string()
+  .min(1)
+  .regex(/^[a-fA-F0-9]{64}$/);
 const AssetCodeSchema = z.string().min(1).max(12);
+
+// ── Mutation input schemas ────────────────────────────────────────────────────
+
+/**
+ * Schema for the `register` mutation input.
+ * Issue #125 – Zod validation for all GraphQL mutations.
+ */
+export const RegisterInputSchema = z.object({
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Must be a valid email address')
+    .max(254, 'Email must be at most 254 characters'),
+  password: z
+    .string({ required_error: 'Password is required' })
+    .min(8, 'Password must be at least 8 characters')
+    .max(128, 'Password must be at most 128 characters')
+    .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+    .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+    .regex(/[0-9]/, 'Password must contain at least one number'),
+  name: z
+    .string({ required_error: 'Name is required' })
+    .min(1, 'Name must not be empty')
+    .max(100, 'Name must be at most 100 characters')
+    .trim(),
+});
+
+/**
+ * Schema for the `login` mutation input.
+ * Issue #125 – Zod validation for all GraphQL mutations.
+ */
+export const LoginInputSchema = z.object({
+  email: z
+    .string({ required_error: 'Email is required' })
+    .email('Must be a valid email address')
+    .max(254, 'Email must be at most 254 characters'),
+  password: z
+    .string({ required_error: 'Password is required' })
+    .min(1, 'Password is required')
+    .max(128, 'Password must be at most 128 characters'),
+});
+
+export type RegisterInput = z.infer<typeof RegisterInputSchema>;
+export type LoginInput = z.infer<typeof LoginInputSchema>;
 
 const PaginationValidationSchema = z.object({
   first: z.number().min(1).max(100).optional(),
@@ -13,89 +62,117 @@ const PaginationValidationSchema = z.object({
   before: CursorSchema.optional(),
 });
 
-const TimeRangeValidationSchema = z.object({
-  startTime: z.string().datetime().optional(),
-  endTime: z.string().datetime().optional(),
-}).refine(
-  (data) => {
-    if (data.startTime && data.endTime) {
-      return new Date(data.startTime) <= new Date(data.endTime);
-    }
-    return true;
-  },
-  { message: 'startTime must be before endTime' }
-);
+const TimeRangeValidationSchema = z
+  .object({
+    startTime: z.string().datetime().optional(),
+    endTime: z.string().datetime().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.startTime && data.endTime) {
+        return new Date(data.startTime) <= new Date(data.endTime);
+      }
+      return true;
+    },
+    { message: 'startTime must be before endTime' }
+  );
 
-const AssetFilterValidationSchema = z.object({
-  assetType: z.enum(['native', 'credit_alphanum4', 'credit_alphanum12']).optional(),
-  assetCode: AssetCodeSchema.optional(),
-  assetIssuer: AddressSchema.optional(),
-}).refine(
-  (data) => {
-    if (data.assetType === 'native') {
-      return !data.assetCode && !data.assetIssuer;
-    }
-    if (data.assetCode || data.assetIssuer) {
-      return data.assetCode && data.assetIssuer;
-    }
-    return true;
-  },
-  { message: 'For non-native assets, both assetCode and assetIssuer must be provided' }
-);
+const AssetFilterValidationSchema = z
+  .object({
+    assetType: z.enum(['native', 'credit_alphanum4', 'credit_alphanum12']).optional(),
+    assetCode: AssetCodeSchema.optional(),
+    assetIssuer: AddressSchema.optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.assetType === 'native') {
+        return !data.assetCode && !data.assetIssuer;
+      }
+      if (data.assetCode || data.assetIssuer) {
+        return data.assetCode && data.assetIssuer;
+      }
+      return true;
+    },
+    { message: 'For non-native assets, both assetCode and assetIssuer must be provided' }
+  );
 
-const AccountFilterValidationSchema = z.object({
-  accountId: AddressSchema.optional(),
-  minBalance: z.string().regex(/^\d+$/).optional(),
-  maxBalance: z.string().regex(/^\d+$/).optional(),
-  isActive: z.boolean().optional(),
-}).refine(
-  (data) => {
-    if (data.minBalance && data.maxBalance) {
-      return parseInt(data.minBalance) <= parseInt(data.maxBalance);
-    }
-    return true;
-  },
-  { message: 'minBalance must be less than or equal to maxBalance' }
-);
+const AccountFilterValidationSchema = z
+  .object({
+    accountId: AddressSchema.optional(),
+    minBalance: z.string().regex(/^\d+$/).optional(),
+    maxBalance: z.string().regex(/^\d+$/).optional(),
+    isActive: z.boolean().optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.minBalance && data.maxBalance) {
+        return parseInt(data.minBalance) <= parseInt(data.maxBalance);
+      }
+      return true;
+    },
+    { message: 'minBalance must be less than or equal to maxBalance' }
+  );
 
-const TransactionFilterValidationSchema = z.object({
-  successful: z.boolean().optional(),
-  minFee: z.number().min(0).optional(),
-  maxFee: z.number().min(0).optional(),
-  hasMemo: z.boolean().optional(),
-  memoType: z.enum(['none', 'text', 'id', 'hash', 'return']).optional(),
-}).refine(
-  (data) => {
-    if (data.minFee && data.maxFee) {
-      return data.minFee <= data.maxFee;
-    }
-    return true;
-  },
-  { message: 'minFee must be less than or equal to maxFee' }
-);
+const TransactionFilterValidationSchema = z
+  .object({
+    successful: z.boolean().optional(),
+    minFee: z.number().min(0).optional(),
+    maxFee: z.number().min(0).optional(),
+    hasMemo: z.boolean().optional(),
+    memoType: z.enum(['none', 'text', 'id', 'hash', 'return']).optional(),
+  })
+  .refine(
+    (data) => {
+      if (data.minFee && data.maxFee) {
+        return data.minFee <= data.maxFee;
+      }
+      return true;
+    },
+    { message: 'minFee must be less than or equal to maxFee' }
+  );
 
 const OperationFilterValidationSchema = z.object({
-  type: z.enum([
-    'create_account', 'payment', 'path_payment_strict_receive',
-    'path_payment_strict_send', 'manage_sell_offer', 'manage_buy_offer',
-    'create_passive_sell_offer', 'set_options', 'change_trust',
-    'allow_trust', 'account_merge', 'inflation', 'manage_data',
-    'bump_sequence', 'claim_claimable_balance',
-    'begin_sponsoring_future_reserves', 'end_sponsoring_future_reserves',
-    'revoke_sponsorship', 'clawback', 'clawback_claimable_balance',
-    'set_trust_line_flags', 'liquidity_pool_deposit',
-    'liquidity_pool_withdraw', 'invoke_host_function',
-  ]).optional(),
+  type: z
+    .enum([
+      'create_account',
+      'payment',
+      'path_payment_strict_receive',
+      'path_payment_strict_send',
+      'manage_sell_offer',
+      'manage_buy_offer',
+      'create_passive_sell_offer',
+      'set_options',
+      'change_trust',
+      'allow_trust',
+      'account_merge',
+      'inflation',
+      'manage_data',
+      'bump_sequence',
+      'claim_claimable_balance',
+      'begin_sponsoring_future_reserves',
+      'end_sponsoring_future_reserves',
+      'revoke_sponsorship',
+      'clawback',
+      'clawback_claimable_balance',
+      'set_trust_line_flags',
+      'liquidity_pool_deposit',
+      'liquidity_pool_withdraw',
+      'invoke_host_function',
+    ])
+    .optional(),
   successful: z.boolean().optional(),
   sourceAccount: AddressSchema.optional(),
 });
 
-function safeParse<T>(schema: z.ZodSchema<T>, data: unknown): { success: true; data: T } | { success: false; error: string } {
+function safeParse<T>(
+  schema: z.ZodSchema<T>,
+  data: unknown
+): { success: true; data: T } | { success: false; error: string } {
   const result = schema.safeParse(data);
   if (result.success) {
     return { success: true, data: result.data };
   }
-  return { success: false, error: result.error.errors.map(e => e.message).join(', ') };
+  return { success: false, error: result.error.errors.map((e) => e.message).join(', ') };
 }
 
 export class ValidationService {
@@ -136,7 +213,12 @@ export class ValidationService {
    * Validate pagination with comprehensive checks
    * Issue #31 – Validate max limit, default limit values, and cursor format
    */
-  static validatePaginationFull(args: { first?: number; after?: string; last?: number; before?: string }): {
+  static validatePaginationFull(args: {
+    first?: number;
+    after?: string;
+    last?: number;
+    before?: string;
+  }): {
     first: number;
     after?: string;
     last?: number;
@@ -145,7 +227,7 @@ export class ValidationService {
   } {
     const errors: string[] = [];
     let first = args.first ?? 20;
-    
+
     const maxLimit = 100;
     const defaultLimit = 20;
 
@@ -249,6 +331,36 @@ export class ValidationService {
     const result = safeParse(HashSchema, hash);
     if (!result.success) {
       throw new GraphQLError(`Invalid hash: ${result.error}`, {
+        extensions: { code: 'VALIDATION_ERROR' },
+      });
+    }
+    return result.data;
+  }
+
+  // ── Mutation validators ─────────────────────────────────────────────────────
+
+  /**
+   * Validate `register` mutation input.
+   * Issue #125 – Zod validation for all GraphQL mutations.
+   */
+  static validateRegisterInput(input: unknown): RegisterInput {
+    const result = safeParse(RegisterInputSchema, input);
+    if (!result.success) {
+      throw new GraphQLError(`Invalid registration input: ${result.error}`, {
+        extensions: { code: 'VALIDATION_ERROR' },
+      });
+    }
+    return result.data;
+  }
+
+  /**
+   * Validate `login` mutation input.
+   * Issue #125 – Zod validation for all GraphQL mutations.
+   */
+  static validateLoginInput(input: unknown): LoginInput {
+    const result = safeParse(LoginInputSchema, input);
+    if (!result.success) {
+      throw new GraphQLError(`Invalid login input: ${result.error}`, {
         extensions: { code: 'VALIDATION_ERROR' },
       });
     }

--- a/packages/frontend/src/pages/Login.tsx
+++ b/packages/frontend/src/pages/Login.tsx
@@ -1,105 +1,202 @@
 /**
  * Login Page
- * 
- * Authentication page for user login.
+ *
+ * Authentication page with client-side form validation.
+ * Issue #124 – Add proper client-side validation with error messages.
+ *
+ * Uses React Hook Form + Zod for field-level validation with
+ * accessible, inline error messages.
  */
 
-import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
-import { LogIn, AlertCircle } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import { LogIn, AlertCircle, Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
 import { useAuthStore } from '@/store';
 import toast from 'react-hot-toast';
+
+// ── Validation schema ─────────────────────────────────────────────────────────
+
+/**
+ * Zod schema for the login form.
+ * Mirrors the server-side LoginInputSchema so errors are caught early.
+ */
+const loginSchema = z.object({
+  email: z
+    .string({ required_error: 'Email is required' })
+    .min(1, 'Email is required')
+    .email('Please enter a valid email address')
+    .max(254, 'Email must be at most 254 characters'),
+  password: z
+    .string({ required_error: 'Password is required' })
+    .min(1, 'Password is required')
+    .max(128, 'Password must be at most 128 characters'),
+});
+
+type LoginFormValues = z.infer<typeof loginSchema>;
+
+// ── Component ─────────────────────────────────────────────────────────────────
 
 export function Login() {
   const navigate = useNavigate();
   const { login } = useAuthStore();
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [serverError, setServerError] = useState('');
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError('');
-    setIsLoading(true);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginSchema),
+    mode: 'onTouched', // validate on blur, then on every change after first touch
+  });
 
+  const onSubmit = async (data: LoginFormValues) => {
+    setServerError('');
     try {
-      await login(email, password);
+      await login(data.email, data.password);
       toast.success('Login successful!');
       navigate('/');
     } catch (err) {
-      setError('Invalid credentials. Please try again.');
+      setServerError('Invalid email or password. Please try again.');
       toast.error('Login failed');
-    } finally {
-      setIsLoading(false);
     }
   };
 
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
       <div className="max-w-md w-full">
+        {/* Header */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-16 h-16 bg-primary rounded-2xl mb-4">
-            <LogIn className="w-8 h-8 text-primary-foreground" />
+            <LogIn className="w-8 h-8 text-primary-foreground" aria-hidden="true" />
           </div>
           <h1 className="text-3xl font-bold mb-2">Welcome Back</h1>
-          <p className="text-muted-foreground">
-            Sign in to access Stellar Analytics Dashboard
-          </p>
+          <p className="text-muted-foreground">Sign in to access Stellar Analytics Dashboard</p>
         </div>
 
         <div className="bg-card border rounded-2xl p-8 shadow-lg">
-          {error && (
-            <div className="mb-6 p-4 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-destructive">{error}</p>
+          {/* Server-level error banner */}
+          {serverError && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="mb-6 p-4 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start gap-3"
+            >
+              <AlertCircle
+                className="w-5 h-5 text-destructive flex-shrink-0 mt-0.5"
+                aria-hidden="true"
+              />
+              <p className="text-sm text-destructive">{serverError}</p>
             </div>
           )}
 
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="space-y-6"
+            noValidate
+            aria-label="Sign in form"
+          >
+            {/* Email field */}
             <div>
               <label htmlFor="email" className="block text-sm font-medium mb-2">
-                Email
+                Email{' '}
+                <span className="text-destructive" aria-hidden="true">
+                  *
+                </span>
               </label>
               <input
                 id="email"
                 type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-background border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                autoComplete="email"
+                aria-required="true"
+                aria-invalid={!!errors.email}
+                aria-describedby={errors.email ? 'email-error' : undefined}
+                {...register('email')}
+                className={`w-full px-4 py-3 bg-background border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all ${
+                  errors.email ? 'border-destructive focus:ring-destructive' : 'border-input'
+                }`}
                 placeholder="you@example.com"
               />
+              {errors.email && (
+                <p
+                  id="email-error"
+                  role="alert"
+                  className="mt-1.5 text-sm text-destructive flex items-center gap-1"
+                >
+                  <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+                  {errors.email.message}
+                </p>
+              )}
             </div>
 
+            {/* Password field */}
             <div>
               <label htmlFor="password" className="block text-sm font-medium mb-2">
-                Password
+                Password{' '}
+                <span className="text-destructive" aria-hidden="true">
+                  *
+                </span>
               </label>
-              <input
-                id="password"
-                type="password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                required
-                className="w-full px-4 py-3 bg-background border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
-                placeholder="••••••••"
-              />
+              <div className="relative">
+                <input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="current-password"
+                  aria-required="true"
+                  aria-invalid={!!errors.password}
+                  aria-describedby={errors.password ? 'password-error' : undefined}
+                  {...register('password')}
+                  className={`w-full px-4 py-3 pr-12 bg-background border rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent transition-all ${
+                    errors.password ? 'border-destructive focus:ring-destructive' : 'border-input'
+                  }`}
+                  placeholder="••••••••"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword((v) => !v)}
+                  aria-label={showPassword ? 'Hide password' : 'Show password'}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors p-1"
+                >
+                  {showPassword ? (
+                    <EyeOff className="w-4 h-4" aria-hidden="true" />
+                  ) : (
+                    <Eye className="w-4 h-4" aria-hidden="true" />
+                  )}
+                </button>
+              </div>
+              {errors.password && (
+                <p
+                  id="password-error"
+                  role="alert"
+                  className="mt-1.5 text-sm text-destructive flex items-center gap-1"
+                >
+                  <AlertCircle className="w-3.5 h-3.5 flex-shrink-0" aria-hidden="true" />
+                  {errors.password.message}
+                </p>
+              )}
             </div>
 
+            {/* Submit button */}
             <button
               type="submit"
-              disabled={isLoading}
+              disabled={isSubmitting}
               className="w-full bg-primary text-primary-foreground px-6 py-3 rounded-lg font-bold hover:opacity-90 transition-opacity disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
             >
-              {isLoading ? (
+              {isSubmitting ? (
                 <>
-                  <div className="w-5 h-5 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin" />
+                  <div
+                    className="w-5 h-5 border-2 border-primary-foreground border-t-transparent rounded-full animate-spin"
+                    aria-hidden="true"
+                  />
                   Signing in...
                 </>
               ) : (
                 <>
-                  <LogIn className="w-5 h-5" />
+                  <LogIn className="w-5 h-5" aria-hidden="true" />
                   Sign In
                 </>
               )}
@@ -108,7 +205,7 @@ export function Login() {
 
           <div className="mt-6 text-center">
             <p className="text-sm text-muted-foreground">
-              Don't have an account?{' '}
+              Don&apos;t have an account?{' '}
               <Link to="/register" className="text-primary hover:underline font-medium">
                 Sign up
               </Link>


### PR DESCRIPTION
…#125)

Issue #125 - Add Zod input validation for all GraphQL mutations
- Add RegisterInputSchema and LoginInputSchema to ValidationService
- Validate register mutation: email format, password strength (min 8 chars, uppercase, lowercase, digit), name length (max 100)
- Validate login mutation: email format, password presence
- generateApiKey and revokeApiKey guarded by auth check (no user input)
- Validation errors surface as GraphQL errors with VALIDATION_ERROR code
- Export RegisterInput and LoginInput types inferred from Zod schemas

Issue #124 - Implement form validation for Login page
- Replace useState-based form with React Hook Form + Zod resolver
- Field-level inline error messages with AlertCircle icon
- Validation mode: onTouched (validate on blur, then on change after touch)
- Email: required, valid format, max 254 chars
- Password: required, max 128 chars
- Show/hide password toggle with Eye/EyeOff icons
- Server error banner separate from field errors
- Accessible: aria-invalid, aria-describedby, aria-required, aria-live, noValidate
closes #124
closes #125