### PR TITLE
feat: cursor-based pagination schema and transaction CSV/JSON export

### DIFF
--- a/packages/api/src/schema/typeDefs.ts
+++ b/packages/api/src/schema/typeDefs.ts
@@ -4,7 +4,12 @@ export const typeDefs = gql`
   scalar DateTime
   scalar JSON
 
-  # Pagination types
+  # ── Pagination ─────────────────────────────────────────────────────────────
+  #
+  # GraphQL SDL does not support generics, so we define concrete Connection /
+  # Edge types for each entity that needs cursor-based pagination.
+  # All Connection types share the same PageInfo shape.
+
   type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
@@ -12,18 +17,8 @@ export const typeDefs = gql`
     endCursor: String
   }
 
-  type Edge<T> {
-    cursor: String!
-    node: T!
-  }
+  # ── Core Stellar types ─────────────────────────────────────────────────────
 
-  type Connection<T> {
-    edges: [Edge<T>]!
-    pageInfo: PageInfo!
-    totalCount: Int!
-  }
-
-  # Core Stellar types
   type Asset {
     assetType: String!
     assetCode: String
@@ -75,7 +70,6 @@ export const typeDefs = gql`
     feeBumpTransaction: Boolean
     innerTransaction: Transaction
     operations: [Operation!]!
-    createdAt: DateTime!
     updatedAt: DateTime!
   }
 
@@ -91,7 +85,6 @@ export const typeDefs = gql`
     ledger: Int!
     operationIndex: Int!
     details: JSON!
-    createdAt: DateTime!
     updatedAt: DateTime!
   }
 
@@ -120,7 +113,65 @@ export const typeDefs = gql`
     updatedAt: DateTime!
   }
 
-  # Analytics types
+  # ── Concrete Connection / Edge types ───────────────────────────────────────
+
+  type LedgerEdge {
+    cursor: String!
+    node: Ledger!
+  }
+
+  type LedgerConnection {
+    edges: [LedgerEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+  }
+
+  type TransactionEdge {
+    cursor: String!
+    node: Transaction!
+  }
+
+  type TransactionConnection {
+    edges: [TransactionEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+  }
+
+  type OperationEdge {
+    cursor: String!
+    node: Operation!
+  }
+
+  type OperationConnection {
+    edges: [OperationEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+  }
+
+  type AccountEdge {
+    cursor: String!
+    node: Account!
+  }
+
+  type AccountConnection {
+    edges: [AccountEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+  }
+
+  type AssetEdge {
+    cursor: String!
+    node: Asset!
+  }
+
+  type AssetConnection {
+    edges: [AssetEdge!]!
+    pageInfo: PageInfo!
+    totalCount: Int!
+  }
+
+  # ── Analytics types ────────────────────────────────────────────────────────
+
   type NetworkMetrics {
     timestamp: DateTime!
     ledgerCount: Int!
@@ -159,7 +210,13 @@ export const typeDefs = gql`
     signers: Int!
   }
 
-  # Filter inputs
+  # ── Filter / pagination inputs ─────────────────────────────────────────────
+
+  """
+  Relay-style cursor pagination input.
+  Use \`first\` + \`after\` for forward pagination,
+  or \`last\` + \`before\` for backward pagination.
+  """
   input PaginationInput {
     first: Int
     after: String
@@ -199,67 +256,66 @@ export const typeDefs = gql`
     sourceAccount: String
   }
 
-  # Queries
+  # ── Queries ────────────────────────────────────────────────────────────────
+
   type Query {
-    # Ledger queries
+    # Ledger queries — cursor-based pagination via LedgerConnection
     ledgers(
       pagination: PaginationInput
       timeRange: TimeRangeInput
-    ): Connection<Ledger>!
-    
+    ): LedgerConnection!
+
     ledger(sequence: Int!): Ledger
 
-    # Transaction queries
+    # Transaction queries — cursor-based pagination via TransactionConnection
     transactions(
       pagination: PaginationInput
       timeRange: TimeRangeInput
       filter: TransactionFilterInput
-    ): Connection<Transaction>!
-    
+    ): TransactionConnection!
+
     transaction(hash: String!): Transaction
 
-    # Operation queries
+    # Operation queries — cursor-based pagination via OperationConnection
     operations(
       pagination: PaginationInput
       timeRange: TimeRangeInput
       filter: OperationFilterInput
-    ): Connection[Operation]!
-    
+    ): OperationConnection!
+
     operation(id: String!): Operation
 
-    # Account queries
+    # Account queries — cursor-based pagination via AccountConnection
     accounts(
       pagination: PaginationInput
       filter: AccountFilterInput
-    ): Connection[Account]!
-    
+    ): AccountConnection!
+
     account(accountId: String!): Account
 
-    # Asset queries
+    # Asset queries — cursor-based pagination via AssetConnection
     assets(
       pagination: PaginationInput
       filter: AssetFilterInput
-    ): Connection[Asset]!
-    
+    ): AssetConnection!
+
     asset(assetType: String!, assetCode: String, assetIssuer: String): Asset
 
     # Analytics queries
-    networkMetrics(
-      timeRange: TimeRangeInput
-    ): [NetworkMetrics!]!
-    
+    networkMetrics(timeRange: TimeRangeInput): [NetworkMetrics!]!
+
     assetMetrics(
       pagination: PaginationInput
       filter: AssetFilterInput
       timeRange: TimeRangeInput
     ): [AssetMetrics!]!
-    
+
     accountMetrics(
       accountId: String!
       timeRange: TimeRangeInput
     ): [AccountMetrics!]!
 
-    # Aggregation queries
+    # Aggregated network statistics
     stats: NetworkStats!
   }
 
@@ -281,7 +337,8 @@ export const typeDefs = gql`
     latestLedgerTime: DateTime!
   }
 
-  # Auth types
+  # ── Auth types ─────────────────────────────────────────────────────────────
+
   type User {
     id: ID!
     email: String!
@@ -311,7 +368,8 @@ export const typeDefs = gql`
     password: String!
   }
 
-  # Mutations
+  # ── Mutations ──────────────────────────────────────────────────────────────
+
   type Mutation {
     register(input: RegisterInput!): AuthPayload!
     login(input: LoginInput!): AuthPayload!
@@ -319,13 +377,14 @@ export const typeDefs = gql`
     revokeApiKey: Boolean!
   }
 
-  # Subscriptions for real-time updates
+  # ── Subscriptions ──────────────────────────────────────────────────────────
+
   type Subscription {
     ledgerAdded: Ledger!
     transactionAdded: Transaction!
     operationAdded: Operation!
     networkMetricsUpdated: NetworkMetrics!
-    
+
     # Filtered subscriptions
     transactionsForAccount(accountId: String!): Transaction!
     operationsForAccount(accountId: String!): Operation!

--- a/packages/frontend/src/graphql/queries.ts
+++ b/packages/frontend/src/graphql/queries.ts
@@ -94,6 +94,39 @@ export const TRANSACTIONS_QUERY = gql`
   }
 `;
 
+/**
+ * Export query — fetches up to 1 000 rows for the current filter set.
+ * Uses a separate operation name so it never merges with the paginated cache.
+ */
+export const TRANSACTIONS_EXPORT_QUERY = gql`
+  query ExportTransactions(
+    $first: Int
+    $timeRange: TimeRangeInput
+    $filter: TransactionFilterInput
+  ) {
+    transactions(
+      pagination: { first: $first }
+      timeRange: $timeRange
+      filter: $filter
+    ) {
+      edges {
+        node {
+          hash
+          successful
+          ledger
+          createdAt
+          sourceAccount
+          feeCharged
+          operationCount
+          memoType
+          memo
+        }
+      }
+      totalCount
+    }
+  }
+`;
+
 export const TRANSACTION_QUERY = gql`
   query GetTransaction($hash: String!) {
     transaction(hash: $hash) {

--- a/packages/frontend/src/pages/Transactions.tsx
+++ b/packages/frontend/src/pages/Transactions.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, useCallback } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { useQuery } from '@apollo/client';
-import { TRANSACTIONS_QUERY } from '@/graphql/queries';
+import { useQuery, useLazyQuery } from '@apollo/client';
+import { TRANSACTIONS_QUERY, TRANSACTIONS_EXPORT_QUERY } from '@/graphql/queries';
 import { DataTable } from '@/components/DataTable';
 import { FilterBar, FilterRow, ToggleGroup, RangeInput, DateRangeInput } from '@/components/FilterBar';
 import { formatDistanceToNow } from 'date-fns';
-import { CheckCircle2, XCircle, Search, RefreshCcw } from 'lucide-react';
+import { CheckCircle2, XCircle, Search, RefreshCcw, Download } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { useFilterSort } from '@/hooks/useFilterSort';
 import type { FilterPreset } from '@/components/FilterBar';
@@ -26,6 +26,10 @@ const DEFAULTS = {
 };
 
 type TxFilters = typeof DEFAULTS;
+
+// ── export format ────────────────────────────────────────────────────────────
+
+type ExportFormat = 'csv' | 'json';
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -77,11 +81,69 @@ function clientSort(txs: any[], field: string, dir: 'asc' | 'desc') {
   });
 }
 
+/**
+ * Flatten a transaction node into a plain record suitable for CSV/JSON export.
+ * Keeps only the fields that are meaningful to an end user.
+ */
+function flattenTransaction(tx: any): Record<string, unknown> {
+  return {
+    hash: tx.hash,
+    successful: tx.successful,
+    ledger: tx.ledger,
+    sourceAccount: tx.sourceAccount,
+    feeCharged: tx.feeCharged,
+    operationCount: tx.operationCount,
+    memoType: tx.memoType ?? '',
+    memo: tx.memo ?? '',
+    createdAt: tx.createdAt,
+  };
+}
+
+/** Convert an array of plain records to a RFC-4180-compliant CSV string. */
+function toCSV(rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) return '';
+  const headers = Object.keys(rows[0]);
+  const escape = (v: unknown): string => {
+    const s = v === null || v === undefined ? '' : String(v);
+    return s.includes(',') || s.includes('"') || s.includes('\n')
+      ? `"${s.replace(/"/g, '""')}"`
+      : s;
+  };
+  return [
+    headers.join(','),
+    ...rows.map((r) => headers.map((h) => escape(r[h])).join(',')),
+  ].join('\n');
+}
+
+/** Trigger a browser file download for the given text content. */
+function triggerDownload(content: string, filename: string, mimeType: string) {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.style.display = 'none';
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/** Generate a timestamped filename, e.g. `transactions-2026-06-01T12-00-00.csv`. */
+function makeFilename(base: string, ext: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  return `${base}-${ts}.${ext}`;
+}
+
 // ── component ────────────────────────────────────────────────────────────────
 
 export function Transactions() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [filterErrors, setFilterErrors] = useState<Record<string, string>>({});
+  const [exportFormat, setExportFormat] = useState<ExportFormat>('csv');
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
   const { filters, sort, setFilter, setSort, resetFilters, activeCount } =
     useFilterSort<TxFilters>({
       defaults: DEFAULTS,
@@ -90,7 +152,9 @@ export function Transactions() {
 
   const after = searchParams.get('after') ?? undefined;
 
-  const { data, loading, fetchMore, refetch } = useQuery(TRANSACTIONS_QUERY, {
+  // ── main paginated query ───────────────────────────────────────────────────
+
+  const { data, loading, refetch } = useQuery(TRANSACTIONS_QUERY, {
     variables: {
       first: 20,
       after,
@@ -101,7 +165,16 @@ export function Transactions() {
     notifyOnNetworkStatusChange: true,
   });
 
-  // Refetch when filters change
+  // ── export query (lazy, network-only, up to 1 000 rows) ───────────────────
+  //
+  // We use a separate lazy query so the export fetch never pollutes the
+  // paginated cache and doesn't block the UI while the user browses.
+
+  const [fetchExport] = useLazyQuery(TRANSACTIONS_EXPORT_QUERY, {
+    fetchPolicy: 'network-only',
+  });
+
+  // Refetch when filters change (reset cursor to page 1)
   const prevFiltersRef = useRef(filters);
   useEffect(() => {
     if (JSON.stringify(prevFiltersRef.current) !== JSON.stringify(filters)) {
@@ -115,11 +188,11 @@ export function Transactions() {
     }
   }, [filters, refetch]);
 
-  const rawTxs = data?.transactions?.edges.map((e: any) => e.node) || [];
+  const rawTxs = data?.transactions?.edges.map((e: any) => e.node) ?? [];
   const pageInfo = data?.transactions?.pageInfo;
   const totalCount = data?.transactions?.totalCount;
 
-  // Client-side search filter (hash / source account)
+  // Client-side search (hash / source account)
   const searched = filters.search
     ? rawTxs.filter(
         (tx: any) =>
@@ -128,10 +201,53 @@ export function Transactions() {
       )
     : rawTxs;
 
-  // Client-side sort
   const sorted = clientSort(searched, sort.field, sort.dir);
 
-  // ── presets ────────────────────────────────────────────────────────────────
+  // ── export handler ─────────────────────────────────────────────────────────
+
+  const handleExport = useCallback(async () => {
+    setIsExporting(true);
+    setExportError(null);
+    try {
+      const result = await fetchExport({
+        variables: {
+          first: 1000,
+          filter: buildGqlFilter(filters),
+          timeRange: buildTimeRange(filters),
+        },
+      });
+
+      const nodes: any[] =
+        result.data?.transactions?.edges?.map((e: any) => e.node) ?? [];
+
+      if (nodes.length === 0) {
+        setExportError('No transactions match the current filters.');
+        return;
+      }
+
+      const rows = nodes.map(flattenTransaction);
+
+      if (exportFormat === 'csv') {
+        triggerDownload(
+          toCSV(rows),
+          makeFilename('transactions', 'csv'),
+          'text/csv;charset=utf-8;'
+        );
+      } else {
+        triggerDownload(
+          JSON.stringify(rows, null, 2),
+          makeFilename('transactions', 'json'),
+          'application/json;charset=utf-8;'
+        );
+      }
+    } catch (err: any) {
+      setExportError(err?.message ?? 'Export failed. Please try again.');
+    } finally {
+      setIsExporting(false);
+    }
+  }, [fetchExport, filters, exportFormat]);
+
+  // ── filter validation ──────────────────────────────────────────────────────
 
   const validateFilters = (updated: TxFilters) => {
     const result = transactionFiltersSchema.safeParse(updated);
@@ -147,38 +263,28 @@ export function Transactions() {
     }
   };
 
+  // ── presets ────────────────────────────────────────────────────────────────
+
   const presets: FilterPreset[] = [
     {
       label: 'Successful only',
       description: 'Show only successful transactions',
-      apply: () => {
-        resetFilters();
-        setFilter('successful', 'true');
-      },
+      apply: () => { resetFilters(); setFilter('successful', 'true'); },
     },
     {
       label: 'Failed only',
       description: 'Show only failed transactions',
-      apply: () => {
-        resetFilters();
-        setFilter('successful', 'false');
-      },
+      apply: () => { resetFilters(); setFilter('successful', 'false'); },
     },
     {
       label: 'With memo',
       description: 'Transactions that carry a memo',
-      apply: () => {
-        resetFilters();
-        setFilter('hasMemo', 'true');
-      },
+      apply: () => { resetFilters(); setFilter('hasMemo', 'true'); },
     },
     {
       label: 'High fee (>1000)',
       description: 'Fee charged above 1000 stroops',
-      apply: () => {
-        resetFilters();
-        setFilter('minFee', '1000');
-      },
+      apply: () => { resetFilters(); setFilter('minFee', '1000'); },
     },
     {
       label: 'Last 24h',
@@ -191,16 +297,16 @@ export function Transactions() {
     },
   ];
 
-  // ── columns ────────────────────────────────────────────────────────────────
+  // ── table columns ──────────────────────────────────────────────────────────
 
   const columns = [
     {
       header: 'Status',
       accessor: (tx: any) =>
         tx.successful ? (
-          <CheckCircle2 className="h-5 w-5 text-green-500" />
+          <CheckCircle2 className="h-5 w-5 text-green-500" aria-label="Successful" />
         ) : (
-          <XCircle className="h-5 w-5 text-red-500" />
+          <XCircle className="h-5 w-5 text-red-500" aria-label="Failed" />
         ),
     },
     {
@@ -252,33 +358,106 @@ export function Transactions() {
     },
   ];
 
+  // ── render ─────────────────────────────────────────────────────────────────
+
   return (
     <div className="space-y-5 animate-in fade-in duration-500">
-      {/* Header */}
+
+      {/* ── Page header ──────────────────────────────────────────────────── */}
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
         <div>
           <h1 className="text-3xl font-bold tracking-tight">Transactions</h1>
           <div className="flex items-center gap-2 mt-1">
-            <span className="relative flex h-2 w-2">
+            <span className="relative flex h-2 w-2" aria-hidden="true">
               <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
               <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
             </span>
             <p className="text-muted-foreground text-sm font-medium">Live network activity</p>
           </div>
         </div>
-        <button
-          onClick={() => refetch()}
-          disabled={loading}
-          className="flex items-center gap-2 px-4 py-2 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors"
-        >
-          <RefreshCcw size={16} className={loading ? 'animate-spin' : ''} />
-          Sync Now
-        </button>
+
+        {/* Action bar */}
+        <div className="flex items-center gap-3 flex-wrap">
+          {/* Sync button */}
+          <button
+            onClick={() => refetch()}
+            disabled={loading}
+            className="flex items-center gap-2 px-4 py-2 bg-secondary text-secondary-foreground rounded-lg hover:bg-secondary/80 transition-colors disabled:opacity-60"
+          >
+            <RefreshCcw size={16} className={loading ? 'animate-spin' : ''} aria-hidden="true" />
+            Sync Now
+          </button>
+
+          {/* ── Export controls ─────────────────────────────────────────── */}
+          <div
+            className="flex items-center gap-2 bg-card border border-border rounded-lg px-3 py-1.5"
+            role="group"
+            aria-label="Export transactions"
+          >
+            {/* Format selector */}
+            <select
+              id="export-format"
+              value={exportFormat}
+              onChange={(e) => setExportFormat(e.target.value as ExportFormat)}
+              disabled={isExporting}
+              aria-label="Select export format"
+              className="text-sm bg-transparent border-none outline-none cursor-pointer text-foreground disabled:opacity-50"
+            >
+              <option value="csv">CSV</option>
+              <option value="json">JSON</option>
+            </select>
+
+            {/* Export button */}
+            <button
+              onClick={handleExport}
+              disabled={isExporting}
+              aria-label={
+                isExporting
+                  ? 'Exporting transactions…'
+                  : `Export transactions as ${exportFormat.toUpperCase()}`
+              }
+              className={clsx(
+                'flex items-center gap-1.5 px-3 py-1 rounded-md text-sm font-medium transition-colors',
+                isExporting
+                  ? 'bg-primary/60 text-primary-foreground cursor-not-allowed'
+                  : 'bg-primary text-primary-foreground hover:bg-primary/90'
+              )}
+            >
+              <Download
+                size={14}
+                aria-hidden="true"
+                className={isExporting ? 'animate-bounce' : ''}
+              />
+              {isExporting ? 'Exporting…' : 'Export'}
+            </button>
+          </div>
+        </div>
       </div>
 
-      {/* Search bar */}
+      {/* ── Export error banner ───────────────────────────────────────────── */}
+      {exportError && (
+        <div
+          role="alert"
+          className="flex items-center justify-between gap-3 px-4 py-3 rounded-lg border border-destructive/40 bg-destructive/10 text-destructive text-sm"
+        >
+          <span>{exportError}</span>
+          <button
+            onClick={() => setExportError(null)}
+            aria-label="Dismiss export error"
+            className="shrink-0 text-destructive/70 hover:text-destructive transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+      )}
+
+      {/* ── Search bar ───────────────────────────────────────────────────── */}
       <div className="relative">
-        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground" size={16} />
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          size={16}
+          aria-hidden="true"
+        />
         <input
           type="text"
           placeholder="Search by hash or source account…"
@@ -297,8 +476,12 @@ export function Transactions() {
         />
       </div>
 
-      {/* Filter bar */}
-      <FilterBar activeCount={activeCount} onReset={() => { resetFilters(); setFilterErrors({}); }} presets={presets}>
+      {/* ── Filter bar ───────────────────────────────────────────────────── */}
+      <FilterBar
+        activeCount={activeCount}
+        onReset={() => { resetFilters(); setFilterErrors({}); }}
+        presets={presets}
+      >
         <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
           <FilterRow label="Status">
             <ToggleGroup
@@ -375,7 +558,7 @@ export function Transactions() {
         </div>
       </FilterBar>
 
-      {/* Table */}
+      {/* ── Data table ───────────────────────────────────────────────────── */}
       <DataTable
         caption="Transactions"
         columns={columns}


### PR DESCRIPTION


closes #118

closes #131

- Fix invalid GraphQL generic syntax in typeDefs (Connection<T>, Edge<T>)
- Add concrete Connection/Edge types for Transaction, Ledger, Operation, Account, Asset
- Extend PageInfo with hasPreviousPage, startCursor, endCursor
- Add CSV/JSON export to Transactions page with filter-aware lazy query
- Add TRANSACTIONS_EXPORT_QUERY to graphql/queries.ts
