### PR TITLE
feat(indexer): add mock Horizon server and local dev guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,475 @@
+# Local Development Guide
+
+Everything a new developer needs to run the Stellar Analytics Dashboard on their machine — no tribal knowledge required.
+
+---
+
+## Table of Contents
+
+1. [Prerequisites](#1-prerequisites)
+2. [First-time setup](#2-first-time-setup)
+3. [Running services](#3-running-services)
+4. [Mock mode (no live Stellar network)](#4-mock-mode-no-live-stellar-network)
+5. [Environment variables reference](#5-environment-variables-reference)
+6. [Port map](#6-port-map)
+7. [Database migrations](#7-database-migrations)
+8. [Running tests](#8-running-tests)
+9. [Common tasks](#9-common-tasks)
+10. [Troubleshooting](#10-troubleshooting)
+
+---
+
+## 1. Prerequisites
+
+| Tool | Minimum version | How to check |
+|------|----------------|--------------|
+| Node.js | 18 | `node --version` |
+| pnpm | 9 | `pnpm --version` |
+| Docker Desktop | any recent | `docker --version` |
+| Docker Compose | v2 (bundled with Desktop) | `docker compose version` |
+| Git | any | `git --version` |
+
+Install pnpm if missing:
+
+```bash
+npm install -g pnpm@9
+```
+
+---
+
+## 2. First-time setup
+
+```bash
+# 1. Clone
+git clone <repo-url>
+cd stellar-analytics-dashboard
+
+# 2. Install all workspace dependencies
+pnpm install
+
+# 3. Start local infrastructure (Postgres + Redis)
+docker compose -f docker-compose.dev.yml up -d postgres redis
+
+# 4. Copy environment files and fill in values
+cp indexer/.env.example          indexer/.env
+cp packages/api/.env.example     packages/api/.env
+
+# 5. Run database migrations
+pnpm db:migrate
+```
+
+The `.env.example` files are pre-filled with values that match the dev
+Docker Compose configuration, so step 4 works out of the box unless you
+changed ports or passwords.
+
+---
+
+## 3. Running services
+
+### All at once (recommended)
+
+```bash
+pnpm dev
+```
+
+This starts the indexer, API, and frontend concurrently using `concurrently`.
+Logs from all three services are colour-coded in the same terminal.
+
+### Individually (useful for focusing on one service)
+
+```bash
+# Indexer  (polls Stellar, writes to Postgres)
+pnpm dev:indexer
+
+# GraphQL API  (serves the dashboard frontend)
+pnpm dev:api
+
+# Frontend  (Vite dev server with HMR)
+pnpm dev:frontend
+```
+
+### Startup order
+
+The services are independent but follow this dependency chain:
+
+```
+Postgres + Redis  →  Indexer  →  API  →  Frontend
+```
+
+The API and Frontend start fine before the Indexer has ingested data — they
+will show empty state until the Indexer writes its first ledger.
+
+---
+
+## 4. Mock mode (no live Stellar network)
+
+By default the indexer connects to the live Stellar Horizon API.  During
+feature development you often don't need real blockchain data and don't want
+to depend on network availability or rate limits.
+
+**Enable mock mode** with a single environment variable:
+
+```bash
+# indexer/.env
+STELLAR_MOCK=true
+```
+
+Or inline for a single run:
+
+```bash
+STELLAR_MOCK=true pnpm dev:indexer
+```
+
+### What mock mode does
+
+- Replaces all `Horizon.Server` calls with a deterministic in-process generator.
+- Produces realistic-looking ledger, transaction, and operation records.
+- Sequence numbers increment on every poll, just like a live network.
+- No network calls, no Horizon account required, works fully offline.
+- Writes data to Postgres just like normal — the API and frontend are unaffected.
+
+### How it works internally
+
+`indexer/src/mock-horizon.ts` exports `createMockHorizonServer()`, a factory
+that returns an object matching the `HorizonServerLike` interface.
+`ingester.ts` resolves which server to use at runtime via the `resolveServer()`
+helper, checked in this order:
+
+1. `serverOverride` argument (used in unit tests)
+2. `STELLAR_MOCK=true` env var → singleton mock
+3. Real `Horizon.Server` connected to the configured network
+
+This means **unit tests never touch the network at all** — they pass a mock
+directly without setting any env var.
+
+### Running offline unit tests
+
+```bash
+# From repo root
+pnpm --filter @stellar-analytics/indexer test
+
+# Or from the indexer folder
+cd indexer
+pnpm test
+```
+
+The `ingester.mock.test.ts` suite covers:
+- Shape validation of `IngestedData`
+- Consecutive poll sequence increments
+- `fetchLedger` and `fetchLedgerRange` helpers
+- Full transformer pipeline compatibility
+- `STELLAR_MOCK=true` env-driven path
+
+These tests are fast (~< 1 s) and require no Docker or network.
+
+---
+
+## 5. Environment variables reference
+
+### Indexer (`indexer/.env`)
+
+```dotenv
+# ── Network ────────────────────────────────────────────────────────────────
+STELLAR_NETWORK=testnet          # testnet | mainnet
+STELLAR_MOCK=false               # true = use built-in mock, no network calls
+
+# ── Database ───────────────────────────────────────────────────────────────
+DATABASE_URL=postgresql://stellar_user:stellar_password@localhost:5432/stellar_analytics_dev
+
+# ── Polling ────────────────────────────────────────────────────────────────
+POLL_INTERVAL_MS=5000            # How often to poll Horizon (ms)
+
+# ── Ports ──────────────────────────────────────────────────────────────────
+HEALTH_PORT=3001                 # Indexer health-check endpoint
+WS_PORT=8080                     # WebSocket broadcast server
+
+# ── Logging ────────────────────────────────────────────────────────────────
+LOG_LEVEL=info                   # trace | debug | info | warn | error | fatal
+LOG_PRETTY=true                  # Human-readable output in dev
+
+# ── Backfill (optional) ────────────────────────────────────────────────────
+BACKFILL_CONCURRENCY=4
+BACKFILL_BATCH_SIZE=10
+BACKFILL_BATCH_DELAY_MS=200
+```
+
+The full list with documentation for every variable is in
+`indexer/.env.example`.
+
+### API (`packages/api/.env`)
+
+```dotenv
+DATABASE_URL=postgresql://stellar_user:stellar_password@localhost:5432/stellar_analytics_dev
+REDIS_URL=redis://localhost:6379
+PORT=4000
+NODE_ENV=development
+CORS_ORIGIN=*
+JWT_SECRET=dev-secret-change-in-production-minimum-32-chars
+LOG_LEVEL=info
+```
+
+The full list is in `packages/api/.env.example`.
+
+### Frontend (Vite)
+
+Create `frontend/.env.local` if you need to override defaults:
+
+```dotenv
+VITE_GRAPHQL_URL=http://localhost:4000/graphql   # default
+VITE_STELLAR_NETWORK=testnet                      # displayed in the UI
+```
+
+The frontend has sensible defaults; no `.env` file is needed for local dev
+unless you change the API port.
+
+---
+
+## 6. Port map
+
+| Service | Port | URL |
+|---------|------|-----|
+| Frontend (Vite HMR) | 5173 | http://localhost:5173 |
+| GraphQL API + Playground | 4000 | http://localhost:4000/graphql |
+| GraphQL WebSocket subscriptions | 4000 | ws://localhost:4000/graphql |
+| Indexer health check | 3001 | http://localhost:3001/health |
+| Indexer readiness probe | 3001 | http://localhost:3001/ready |
+| Indexer WebSocket broadcast | 8080 | ws://localhost:8080 |
+| PostgreSQL | 5432 | localhost:5432 |
+| Redis | 6379 | localhost:6379 |
+
+---
+
+## 7. Database migrations
+
+Migrations are managed with `node-pg-migrate` and live in
+`packages/indexer/migrations/`.
+
+```bash
+# Apply all pending migrations
+pnpm db:migrate
+
+# Roll back the last migration
+pnpm db:migrate:down
+
+# Create a new migration file
+pnpm db:migrate:create describe_your_change
+```
+
+To fully reset the dev database:
+
+```bash
+docker compose -f docker-compose.dev.yml down -v   # removes volumes
+docker compose -f docker-compose.dev.yml up -d postgres redis
+pnpm db:migrate
+```
+
+See `docs/database-migrations.md` for rollback and CI guidance.
+
+---
+
+## 8. Running tests
+
+### All tests (unit + integration)
+
+```bash
+pnpm test:ci
+```
+
+### By package
+
+```bash
+# Indexer unit tests (includes offline mock tests — no network required)
+pnpm --filter @stellar-analytics/indexer test
+
+# API unit tests
+pnpm --filter @stellar-analytics/api test
+
+# Frontend unit tests (Vitest)
+pnpm --filter @stellar-analytics/frontend test:ci
+```
+
+### E2E tests (requires running stack)
+
+```bash
+# Headless
+pnpm test:e2e
+
+# With Playwright UI
+pnpm test:e2e:ui
+
+# Single browser
+pnpm test:e2e:chrome
+pnpm test:e2e:firefox
+pnpm test:e2e:webkit
+```
+
+E2E tests spin up their own Postgres and Redis via Docker — you don't need
+the dev compose stack running separately.
+
+### Indexer tests — live vs mock
+
+| Test file | Needs network? | Needs DB? |
+|-----------|----------------|-----------|
+| `ingester.mock.test.ts` | **No** | No |
+| `ingester.test.ts` | **Yes** (testnet) | No |
+| `config.test.ts` | No | No |
+
+Run only the offline tests with:
+
+```bash
+cd indexer
+pnpm test -- --testPathPattern="mock"
+```
+
+---
+
+## 9. Common tasks
+
+### Check if all services are healthy
+
+```bash
+# Indexer
+curl http://localhost:3001/health
+
+# API
+curl http://localhost:4000/health
+
+# Postgres (via Docker)
+docker compose -f docker-compose.dev.yml exec postgres pg_isready -U stellar_user
+```
+
+### Trigger a manual backfill
+
+```bash
+# Backfill from ledger 1000000 to latest
+curl -X POST http://localhost:3001/backfill \
+  -H "Content-Type: application/json" \
+  -d '{"startSequence": 1000000}'
+```
+
+### Open the GraphQL Playground
+
+Navigate to http://localhost:4000/graphql in your browser.  The playground is
+enabled automatically in development (`NODE_ENV !== 'production'`).
+
+### Wipe and reseed local data
+
+```bash
+# Reset the database volume and re-migrate
+docker compose -f docker-compose.dev.yml down -v
+docker compose -f docker-compose.dev.yml up -d postgres redis
+pnpm db:migrate
+
+# Then start the indexer (or use mock mode) to repopulate
+STELLAR_MOCK=true pnpm dev:indexer
+```
+
+### Lint and format
+
+```bash
+pnpm lint          # check
+pnpm lint:fix      # auto-fix
+pnpm format        # prettier
+```
+
+---
+
+## 10. Troubleshooting
+
+### `pnpm install` fails with workspace errors
+
+Make sure you are at the repo root (where `pnpm-workspace.yaml` is) and that
+your pnpm version is ≥ 9:
+
+```bash
+pnpm --version
+# if < 9:
+npm install -g pnpm@9
+```
+
+### `pnpm db:migrate` fails: "connection refused"
+
+Postgres isn't running. Start it:
+
+```bash
+docker compose -f docker-compose.dev.yml up -d postgres
+```
+
+Then verify:
+
+```bash
+docker compose -f docker-compose.dev.yml ps
+```
+
+### Indexer exits with "Missing required environment variables"
+
+Copy the example file and verify the values match your Docker Compose config:
+
+```bash
+cp indexer/.env.example indexer/.env
+```
+
+The defaults in `.env.example` are pre-configured for the dev compose stack.
+
+### API exits with "Missing required environment variables"
+
+```bash
+cp packages/api/.env.example packages/api/.env
+```
+
+### Frontend shows "Network error" or blank dashboard
+
+1. Confirm the API is running: `curl http://localhost:4000/graphql`
+2. Check `VITE_GRAPHQL_URL` in `frontend/.env.local` (defaults to `http://localhost:4000/graphql`)
+3. Look at the browser console for the actual Apollo error
+
+### Port already in use
+
+Check what is using the port and stop it, or change the port in `.env`:
+
+```bash
+# Windows
+netstat -ano | findstr :<PORT>
+taskkill /PID <PID> /F
+
+# macOS / Linux
+lsof -i :<PORT>
+kill <PID>
+```
+
+### `STELLAR_MOCK=true` but no data appears in the frontend
+
+The mock writes data to Postgres just like real data. Verify:
+
+1. Postgres is running (`docker compose -f docker-compose.dev.yml ps`)
+2. Migrations have been applied (`pnpm db:migrate`)
+3. The indexer log shows `[indexer] processed ledger <N>`
+4. The API is running and can reach Postgres (`curl http://localhost:4000/health`)
+
+### Docker Compose: `Error response from daemon: network not found`
+
+```bash
+docker compose -f docker-compose.dev.yml down
+docker compose -f docker-compose.dev.yml up -d
+```
+
+### Tests fail with "Cannot find module '../src/logger.js'"
+
+Run `pnpm install` from the repo root to ensure all workspace symlinks are
+resolved.
+
+---
+
+## Further reading
+
+| Document | What it covers |
+|----------|----------------|
+| `CONTRIBUTING.md` | Branch strategy, commit conventions, PR checklist |
+| `CACHING.md` | Redis TTL strategy and cache-aside pattern |
+| `docs/database-migrations.md` | Migration workflow, rollback, CI |
+| `docs/query-performance.md` | Indexes, slow-query monitoring, DataLoader |
+| `docs/error-handling-and-logging.md` | Winston config, log levels, error codes |
+| `docs/security-headers.md` | Helmet configuration |
+| `docs/cors.md` | CORS setup for multi-origin deployments |
+| `indexer/ALERTING.md` | Slack / email alert configuration |
+| `indexer/BACKFILL.md` | Backfill CLI reference |

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ Shared network configuration is in `shared/src/config/networks.ts`:
 
 ## Local Setup
 
+> **New to the project?** See [DEVELOPMENT.md](./DEVELOPMENT.md) for a complete step-by-step guide covering prerequisites, environment variables, mock mode, port map, and troubleshooting.
+
 1. Install dependencies:
 
 ```bash
@@ -61,8 +63,32 @@ pnpm install
 2. Start PostgreSQL and Redis:
 
 ```bash
-docker compose up -d postgres redis
+docker compose -f docker-compose.dev.yml up -d postgres redis
 ```
+
+3. Copy and configure environment files:
+
+```bash
+cp indexer/.env.example       indexer/.env
+cp packages/api/.env.example  packages/api/.env
+```
+
+4. Run migrations:
+
+```bash
+pnpm db:migrate
+```
+
+5. Start all services:
+
+```bash
+pnpm dev
+```
+
+### Mock mode (no Stellar network required)
+
+Set `STELLAR_MOCK=true` in `indexer/.env` to run the indexer fully offline
+using deterministic generated data. See [DEVELOPMENT.md § Mock mode](./DEVELOPMENT.md#4-mock-mode-no-live-stellar-network) for details.
 
 ### CI/CD
 

--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -13,6 +13,12 @@
 # Default: testnet
 STELLAR_NETWORK=testnet
 
+# Use the built-in mock Horizon server instead of connecting to a live network.
+# Produces deterministic ledger/transaction/operation data with no network calls.
+# Useful during feature development and for running unit tests offline.
+# Default: false
+STELLAR_MOCK=false
+
 # -----------------------------------------------------------------------------
 # Database (PostgreSQL)
 # -----------------------------------------------------------------------------

--- a/indexer/src/ingester.ts
+++ b/indexer/src/ingester.ts
@@ -8,9 +8,57 @@ export interface IngestedData {
   operations: Horizon.ServerApi.OperationRecord[];
 }
 
-export async function pollLatestLedger(network: StellarNetwork): Promise<IngestedData> {
+/**
+ * A minimal interface covering only the Horizon.Server methods used by
+ * this module.  Accepting this interface instead of the concrete class lets
+ * tests inject a mock without monkey-patching the SDK.
+ */
+export interface HorizonServerLike {
+  ledgers(): {
+    order(dir: string): { limit(n: number): { call(): Promise<{ records: any[] }> } };
+    ledger(seq: number): { call(): Promise<{ records?: any[]; sequence?: number }> };
+  };
+  transactions(): {
+    forLedger(seq: number): {
+      limit(n: number): { call(): Promise<{ records: any[] }> };
+      call(): Promise<{ records: any[] }>;
+    };
+  };
+  operations(): {
+    forLedger(seq: number): {
+      limit(n: number): { call(): Promise<{ records: any[] }> };
+      call(): Promise<{ records: any[] }>;
+    };
+  };
+}
+
+/**
+ * Resolve the server to use:
+ *  - If `serverOverride` is provided (e.g. in tests), use it directly.
+ *  - If `STELLAR_MOCK=true` env var is set, use the built-in mock server.
+ *  - Otherwise create a real Horizon.Server for the given network.
+ */
+async function resolveServer(
+  network: StellarNetwork,
+  serverOverride?: HorizonServerLike
+): Promise<HorizonServerLike> {
+  if (serverOverride) return serverOverride;
+
+  if (process.env.STELLAR_MOCK === "true") {
+    // Lazy import so the mock module is never loaded in production bundles
+    const { getMockHorizonServer } = await import("./mock-horizon.js");
+    return getMockHorizonServer() as unknown as HorizonServerLike;
+  }
+
   const config = STELLAR_NETWORKS[network];
-  const server = new Horizon.Server(config.horizonUrl);
+  return new Horizon.Server(config.horizonUrl) as unknown as HorizonServerLike;
+}
+
+export async function pollLatestLedger(
+  network: StellarNetwork,
+  serverOverride?: HorizonServerLike
+): Promise<IngestedData> {
+  const server = await resolveServer(network, serverOverride);
 
   try {
     ingesterLogger.debug({ network }, "Polling Horizon for latest ledger");
@@ -59,10 +107,10 @@ export async function pollLatestLedger(network: StellarNetwork): Promise<Ingeste
  */
 export async function fetchLedger(
   network: StellarNetwork,
-  sequence: number
+  sequence: number,
+  serverOverride?: HorizonServerLike
 ): Promise<IngestedData> {
-  const config = STELLAR_NETWORKS[network];
-  const server = new Horizon.Server(config.horizonUrl);
+  const server = await resolveServer(network, serverOverride);
 
   const ledgerResp = await (server.ledgers().ledger(sequence) as any).call();
   const ledger: Horizon.ServerApi.LedgerRecord =
@@ -87,11 +135,12 @@ export async function fetchLedger(
 export async function fetchLedgerRange(
   network: StellarNetwork,
   start: number,
-  end: number
+  end: number,
+  serverOverride?: HorizonServerLike
 ): Promise<IngestedData[]> {
   const results: IngestedData[] = [];
   for (let seq = start; seq <= end; seq++) {
-    results.push(await fetchLedger(network, seq));
+    results.push(await fetchLedger(network, seq, serverOverride));
   }
   return results;
 }

--- a/indexer/src/mock-horizon.ts
+++ b/indexer/src/mock-horizon.ts
@@ -1,0 +1,312 @@
+/**
+ * mock-horizon.ts
+ *
+ * A self-contained, deterministic mock of the Horizon API surface used by
+ * the ingester.  It produces realistic-looking ledger, transaction, and
+ * operation records without making any network calls.
+ *
+ * Usage (env-driven):
+ *   STELLAR_MOCK=true  tsx src/index.ts
+ *
+ * Usage (programmatic – for unit tests):
+ *   import { createMockHorizonServer } from './mock-horizon.js';
+ *   const server = createMockHorizonServer({ startSequence: 100 });
+ */
+
+// ---------------------------------------------------------------------------
+// Minimal subset of the Horizon SDK types that ingester.ts actually touches
+// ---------------------------------------------------------------------------
+
+export interface MockLedgerRecord {
+  sequence: number;
+  hash: string;
+  closed_at: string;
+  successful_transaction_count: number;
+  failed_transaction_count: number;
+  operation_count: number;
+  tx_set_operation_count: number;
+  total_coins: string;
+  fee_pool: string;
+  base_fee_in_stroops: number;
+  base_reserve_in_stroops: number;
+  max_tx_set_size: number;
+  protocol_version: number;
+  header_xdr: string;
+}
+
+export interface MockTransactionRecord {
+  id: string;
+  paging_token: string;
+  successful: boolean;
+  hash: string;
+  /** The ledger sequence number */
+  ledger: number;
+  created_at: string;
+  source_account: string;
+  source_account_sequence: string;
+  fee_account: string;
+  fee_charged: string;
+  max_fee: string;
+  operation_count: number;
+  envelope_xdr: string;
+  result_xdr: string;
+  result_meta_xdr: string;
+  fee_meta_xdr: string;
+  memo_type: string;
+  signatures: string[];
+  transaction_hash: string;
+}
+
+export interface MockOperationRecord {
+  id: string;
+  paging_token: string;
+  transaction_hash: string;
+  transaction_successful: boolean;
+  type: string;
+  created_at: string;
+  source_account: string;
+  /** payment-specific */
+  from?: string;
+  to?: string;
+  amount?: string;
+  asset_type?: string;
+  asset_code?: string;
+  asset_issuer?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic data generators
+// ---------------------------------------------------------------------------
+
+/** Pad a number to a fixed hex width */
+function hexPad(n: number, width = 64): string {
+  return n.toString(16).padStart(width, "0");
+}
+
+/** Pseudo-random Stellar account-ID (not a real key-pair) */
+function mockAccountId(seed: number): string {
+  return `GAAA${seed.toString().padStart(52, "0")}`;
+}
+
+function mockLedger(sequence: number): MockLedgerRecord {
+  const closedAt = new Date(Date.now() - (1000 - sequence % 1000) * 5_000);
+  return {
+    sequence,
+    hash: hexPad(sequence),
+    closed_at: closedAt.toISOString(),
+    successful_transaction_count: 3 + (sequence % 5),
+    failed_transaction_count: sequence % 2,
+    operation_count: 6 + (sequence % 10),
+    tx_set_operation_count: 6 + (sequence % 10),
+    total_coins: "100000000000.0000000",
+    fee_pool: "1234.5678900",
+    base_fee_in_stroops: 100,
+    base_reserve_in_stroops: 5_000_000,
+    max_tx_set_size: 500,
+    protocol_version: 20,
+    header_xdr: `MOCK_LEDGER_XDR_${sequence}`,
+  };
+}
+
+function mockTransactions(
+  ledgerSequence: number,
+  count: number
+): MockTransactionRecord[] {
+  return Array.from({ length: count }, (_, i) => {
+    const hash = hexPad(ledgerSequence * 1000 + i);
+    const created = new Date(Date.now() - (count - i) * 1_000).toISOString();
+    return {
+      id: hash,
+      paging_token: `${ledgerSequence}-${i}`,
+      successful: i % 7 !== 0, // ~85% success rate
+      hash,
+      ledger: ledgerSequence,
+      created_at: created,
+      source_account: mockAccountId(i + 1),
+      source_account_sequence: String(ledgerSequence * 10 + i),
+      fee_account: mockAccountId(i + 1),
+      fee_charged: String(100 * (1 + (i % 3))),
+      max_fee: "10000",
+      operation_count: 1 + (i % 3),
+      envelope_xdr: `MOCK_TX_ENVELOPE_XDR_${hash}`,
+      result_xdr: "AAAAAAAAAGQ=",
+      result_meta_xdr: "MOCK_META",
+      fee_meta_xdr: "MOCK_FEE_META",
+      memo_type: "none",
+      signatures: [],
+      transaction_hash: hash,
+    };
+  });
+}
+
+const OP_TYPES = [
+  "payment",
+  "create_account",
+  "path_payment_strict_receive",
+  "manage_sell_offer",
+  "change_trust",
+  "account_merge",
+];
+
+function mockOperations(
+  ledgerSequence: number,
+  txHashes: string[],
+  opsPerTx: number
+): MockOperationRecord[] {
+  const ops: MockOperationRecord[] = [];
+  txHashes.forEach((txHash, ti) => {
+    for (let oi = 0; oi < opsPerTx; oi++) {
+      const type = OP_TYPES[(ti + oi) % OP_TYPES.length];
+      const created = new Date(Date.now() - oi * 200).toISOString();
+      const op: MockOperationRecord = {
+        id: `${ledgerSequence}-${ti}-${oi}`,
+        paging_token: `${ledgerSequence}-${ti}-${oi}`,
+        transaction_hash: txHash,
+        transaction_successful: true,
+        type,
+        created_at: created,
+        source_account: mockAccountId(ti + oi + 10),
+      };
+      if (type === "payment" || type === "path_payment_strict_receive") {
+        op.from = mockAccountId(ti + 1);
+        op.to = mockAccountId(ti + 2);
+        op.amount = String((100 + ti * 10 + oi).toFixed(7));
+        op.asset_type = "native";
+        op.asset_code = "XLM";
+      }
+      ops.push(op);
+    }
+  });
+  return ops;
+}
+
+// ---------------------------------------------------------------------------
+// Mock server factory
+// ---------------------------------------------------------------------------
+
+export interface MockHorizonOptions {
+  /**
+   * Starting ledger sequence.  Each call to the mock's `ledgers()` chain
+   * increments this by 1, simulating real-time ledger closing.
+   * @default 100
+   */
+  startSequence?: number;
+  /**
+   * Number of transactions to generate per ledger.
+   * @default 3
+   */
+  txsPerLedger?: number;
+  /**
+   * Number of operations to generate per transaction.
+   * @default 2
+   */
+  opsPerTx?: number;
+}
+
+/**
+ * Creates a mock object that mimics the `Horizon.Server` interface used by
+ * `ingester.ts`.  Only the methods actually called by the ingester are
+ * implemented; everything else is a no-op stub.
+ *
+ * The mock is stateful: each call to `.ledgers().order('desc').limit(1).call()`
+ * advances the internal sequence counter so it behaves like a live stream.
+ */
+export function createMockHorizonServer(options: MockHorizonOptions = {}) {
+  let currentSequence = options.startSequence ?? 100;
+  const txsPerLedger = options.txsPerLedger ?? 3;
+  const opsPerTx = options.opsPerTx ?? 2;
+
+  /** Returns the latest generated sequence (useful in assertions) */
+  const getLastSequence = () => currentSequence;
+  const resetSequence = (seq: number) => { currentSequence = seq; };
+
+  // ── Chain builders ──────────────────────────────────────────────────────
+
+  function makeLedgersChain(sequence: number) {
+    const ledger = mockLedger(sequence);
+    return {
+      order: () => ({
+        limit: () => ({
+          call: async () => ({ records: [ledger] }),
+        }),
+      }),
+      ledger: (seq: number) => ({
+        call: async () => {
+          const l = mockLedger(seq);
+          return { records: [l] };
+        },
+      }),
+    };
+  }
+
+  function makeTxsChain(sequence: number) {
+    const txs = mockTransactions(sequence, txsPerLedger);
+    return {
+      forLedger: () => ({
+        limit: () => ({
+          call: async () => ({ records: txs }),
+        }),
+        call: async () => ({ records: txs }),
+      }),
+    };
+  }
+
+  function makeOpsChain(sequence: number) {
+    const txs = mockTransactions(sequence, txsPerLedger);
+    const txHashes = txs.map((t) => t.hash);
+    const ops = mockOperations(sequence, txHashes, opsPerTx);
+    return {
+      forLedger: () => ({
+        limit: () => ({
+          call: async () => ({ records: ops }),
+        }),
+        call: async () => ({ records: ops }),
+      }),
+    };
+  }
+
+  // ── Public server interface ─────────────────────────────────────────────
+
+  return {
+    /** Advance state – call before each ingestion cycle in tests */
+    __advance: () => { currentSequence += 1; },
+    __getLastSequence: getLastSequence,
+    __resetSequence: resetSequence,
+    __generateLedger: (seq?: number) => mockLedger(seq ?? currentSequence),
+    __generateTransactions: (seq?: number) =>
+      mockTransactions(seq ?? currentSequence, txsPerLedger),
+
+    ledgers() {
+      const seq = currentSequence;
+      currentSequence += 1; // advance on each poll, like real Horizon
+      return makeLedgersChain(seq);
+    },
+
+    transactions() {
+      return makeTxsChain(currentSequence - 1);
+    },
+
+    operations() {
+      return makeOpsChain(currentSequence - 1);
+    },
+  };
+}
+
+export type MockHorizonServer = ReturnType<typeof createMockHorizonServer>;
+
+// ---------------------------------------------------------------------------
+// Environment-driven singleton  (used by the indexer when STELLAR_MOCK=true)
+// ---------------------------------------------------------------------------
+
+let _singleton: MockHorizonServer | null = null;
+
+export function getMockHorizonServer(options?: MockHorizonOptions): MockHorizonServer {
+  if (!_singleton) {
+    _singleton = createMockHorizonServer(options);
+  }
+  return _singleton;
+}
+
+export function resetMockHorizonSingleton(): void {
+  _singleton = null;
+}

--- a/indexer/tests/ingester.mock.test.ts
+++ b/indexer/tests/ingester.mock.test.ts
@@ -1,0 +1,245 @@
+/**
+ * ingester.mock.test.ts
+ *
+ * Unit tests for the Stellar ingester that run entirely offline – no live
+ * Horizon calls, no database, no network required.
+ *
+ * Acceptance criteria:
+ *  ✓ pollLatestLedger() returns a valid IngestedData shape from the mock
+ *  ✓ Sequence numbers increment on consecutive polls (simulates live stream)
+ *  ✓ fetchLedger() returns data for a specific sequence
+ *  ✓ fetchLedgerRange() returns the correct number of ledgers in order
+ *  ✓ Errors are propagated correctly when the mock throws
+ *  ✓ Transformer produces non-empty normalized output from mock data
+ *  ✓ Mock data satisfies the schema expected by loader (column shapes)
+ */
+
+import { pollLatestLedger, fetchLedger, fetchLedgerRange } from "../src/ingester.js";
+import {
+  createMockHorizonServer,
+  resetMockHorizonSingleton,
+} from "../src/mock-horizon.js";
+import {
+  normalizeLedger,
+  normalizeTransactions,
+  normalizeOperations,
+  normalizePayments,
+} from "../src/transformer.js";
+
+// Silence logger output during tests
+jest.mock("../src/logger.js", () => ({
+  ingesterLogger: {
+    debug: jest.fn(),
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+  configLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+  indexerLogger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    fatal: jest.fn(),
+    debug: jest.fn(),
+  },
+  loaderLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  backfillLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  workerLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  websocketLogger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+beforeEach(() => {
+  // Ensure the env-driven singleton is cleared between tests
+  resetMockHorizonSingleton();
+});
+
+// ---------------------------------------------------------------------------
+// pollLatestLedger
+// ---------------------------------------------------------------------------
+
+describe("pollLatestLedger (mock server)", () => {
+  it("returns a well-shaped IngestedData object", async () => {
+    const mock = createMockHorizonServer({ startSequence: 500, txsPerLedger: 3, opsPerTx: 2 });
+    const data = await pollLatestLedger("testnet", mock as any);
+
+    expect(data).toBeDefined();
+    expect(data.ledger).toBeDefined();
+    expect(typeof data.ledger.sequence).toBe("number");
+    expect(data.ledger.sequence).toBeGreaterThan(0);
+    expect(typeof data.ledger.hash).toBe("string");
+    expect(typeof data.ledger.closed_at).toBe("string");
+
+    expect(Array.isArray(data.transactions)).toBe(true);
+    expect(Array.isArray(data.operations)).toBe(true);
+  });
+
+  it("returns the expected number of transactions and operations", async () => {
+    const mock = createMockHorizonServer({ startSequence: 200, txsPerLedger: 4, opsPerTx: 3 });
+    const data = await pollLatestLedger("testnet", mock as any);
+
+    expect(data.transactions.length).toBe(4);
+    // 4 txs × 3 ops each = 12 operations
+    expect(data.operations.length).toBe(12);
+  });
+
+  it("sequence increments on consecutive polls", async () => {
+    const mock = createMockHorizonServer({ startSequence: 1000 });
+
+    const first = await pollLatestLedger("testnet", mock as any);
+    const second = await pollLatestLedger("testnet", mock as any);
+
+    expect(second.ledger.sequence).toBe(first.ledger.sequence + 1);
+  });
+
+  it("each transaction has a hash that matches the operations' transaction_hash", async () => {
+    const mock = createMockHorizonServer({ startSequence: 300, txsPerLedger: 2, opsPerTx: 1 });
+    const data = await pollLatestLedger("testnet", mock as any);
+
+    const txHashes = new Set(data.transactions.map((tx) => tx.hash));
+    for (const op of data.operations) {
+      expect(txHashes.has((op as any).transaction_hash)).toBe(true);
+    }
+  });
+
+  it("works with mainnet network label (same mock behaviour)", async () => {
+    const mock = createMockHorizonServer({ startSequence: 50 });
+    const data = await pollLatestLedger("mainnet", mock as any);
+
+    expect(data.ledger.sequence).toBe(50);
+  });
+
+  it("throws when the mock has no ledger records", async () => {
+    // Manually craft a server that returns empty records
+    const emptyServer = {
+      ledgers: () => ({
+        order: () => ({ limit: () => ({ call: async () => ({ records: [] }) }) }),
+        ledger: () => ({ call: async () => ({ records: [] }) }),
+      }),
+      transactions: () => ({ forLedger: () => ({ call: async () => ({ records: [] }), limit: () => ({ call: async () => ({ records: [] }) }) }) }),
+      operations: () => ({ forLedger: () => ({ call: async () => ({ records: [] }), limit: () => ({ call: async () => ({ records: [] }) }) }) }),
+    };
+
+    await expect(pollLatestLedger("testnet", emptyServer as any)).rejects.toThrow(
+      "No ledgers found on Horizon"
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLedger
+// ---------------------------------------------------------------------------
+
+describe("fetchLedger (mock server)", () => {
+  it("fetches a ledger with the requested sequence number", async () => {
+    const mock = createMockHorizonServer({ startSequence: 42 });
+    const data = await fetchLedger("testnet", 42, mock as any);
+
+    expect(data.ledger).toBeDefined();
+    // Mock ledger() returns the record with the requested sequence
+    expect(data.transactions.length).toBeGreaterThan(0);
+    expect(data.operations.length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchLedgerRange
+// ---------------------------------------------------------------------------
+
+describe("fetchLedgerRange (mock server)", () => {
+  it("returns the correct number of ledgers", async () => {
+    const mock = createMockHorizonServer({ startSequence: 10 });
+    const results = await fetchLedgerRange("testnet", 10, 14, mock as any);
+
+    expect(results).toHaveLength(5);
+  });
+
+  it("results contain non-empty transaction arrays", async () => {
+    const mock = createMockHorizonServer({ startSequence: 20 });
+    const results = await fetchLedgerRange("testnet", 20, 22, mock as any);
+
+    for (const r of results) {
+      expect(r.transactions.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Transformer compatibility
+// ---------------------------------------------------------------------------
+
+describe("transformer produces valid DB-ready data from mock output", () => {
+  it("normalizeLedger returns required fields", async () => {
+    const mock = createMockHorizonServer({ startSequence: 600 });
+    const data = await pollLatestLedger("testnet", mock as any);
+    const ledger = normalizeLedger(data as any);
+
+    expect(typeof ledger.sequence).toBe("number");
+    expect(typeof ledger.hash).toBe("string");
+    expect(typeof ledger.close_time).toBe("string");
+    expect(typeof ledger.tx_count).toBe("number");
+  });
+
+  it("normalizeTransactions returns an array with hash and source_account", async () => {
+    const mock = createMockHorizonServer({ startSequence: 700, txsPerLedger: 5 });
+    const data = await pollLatestLedger("testnet", mock as any);
+    const txs = normalizeTransactions(data as any);
+
+    expect(txs.length).toBe(5);
+    for (const tx of txs) {
+      expect(typeof tx.hash).toBe("string");
+      expect(typeof tx.source_account).toBe("string");
+      expect(typeof tx.ledger_seq).toBe("number");
+    }
+  });
+
+  it("normalizeOperations returns array with id and type", async () => {
+    const mock = createMockHorizonServer({ startSequence: 800, txsPerLedger: 2, opsPerTx: 3 });
+    const data = await pollLatestLedger("testnet", mock as any);
+    const ops = normalizeOperations(data as any);
+
+    expect(ops.length).toBe(6);
+    for (const op of ops) {
+      expect(typeof op.id).toBe("string");
+      expect(typeof op.type).toBe("string");
+    }
+  });
+
+  it("normalizePayments only includes payment-type operations", async () => {
+    const mock = createMockHorizonServer({ startSequence: 900, txsPerLedger: 6, opsPerTx: 1 });
+    const data = await pollLatestLedger("testnet", mock as any);
+    const payments = normalizePayments(data as any);
+
+    const PAYMENT_TYPES = ["payment", "path_payment_strict_receive", "path_payment_strict_send"];
+    for (const p of payments) {
+      // Each payment must have originated from a payment-type op
+      expect(p.amount).toBeDefined();
+      expect(p.from).toBeDefined();
+    }
+    // Not all ops are payments – result count should be ≤ total ops
+    expect(payments.length).toBeLessThanOrEqual(data.operations.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// STELLAR_MOCK env flag (integration with the env-driven path)
+// ---------------------------------------------------------------------------
+
+describe("STELLAR_MOCK environment flag", () => {
+  const originalEnv = process.env.STELLAR_MOCK;
+
+  afterEach(() => {
+    process.env.STELLAR_MOCK = originalEnv;
+    resetMockHorizonSingleton();
+  });
+
+  it("uses the singleton mock when STELLAR_MOCK=true (no server override)", async () => {
+    process.env.STELLAR_MOCK = "true";
+
+    // Without passing a server override, the env-driven path is used
+    const data = await pollLatestLedger("testnet");
+
+    expect(data.ledger.sequence).toBeGreaterThan(0);
+    expect(Array.isArray(data.transactions)).toBe(true);
+  });
+});


### PR DESCRIPTION


closes #259
closes #267

## Summary

Two developer experience improvements.

### a) Mock Horizon server — reduce dependency on live services

- `indexer/src/mock-horizon.ts` — deterministic drop-in for `Horizon.Server`.
  Generates realistic ledger/transaction/operation records with no network calls.
  Configurable via `startSequence`, `txsPerLedger`, `opsPerTx`.
- `indexer/src/ingester.ts` — introduces `HorizonServerLike` interface and
  `resolveServer()` helper. Resolution order: serverOverride arg →
  STELLAR_MOCK=true env → real Horizon. Production path is unchanged.
- `indexer/tests/ingester.mock.test.ts` — 14 offline unit tests: shape
  validation, sequence increments, error propagation, transformer pipeline,
  env-driven singleton path.
- `indexer/.env.example` — documents new STELLAR_MOCK flag.

### b) Local development guide — no tribal knowledge required

- `DEVELOPMENT.md` — 10-section guide: prerequisites, first-time setup,
  running services, mock mode internals, env var reference, port map,
  migrations, test matrix, common tasks, troubleshooting.
- `README.md` — updated to reference DEVELOPMENT.md and fix compose file.

## Testing

`ingester.mock.test.ts` runs fully offline (no DB, no network).
Existing tests are unaffected.
