### PR TITLE
feat(charts): improve tooltip and legend styling across all chart components

### DIFF
--- a/packages/frontend/src/components/ChartLegend.tsx
+++ b/packages/frontend/src/components/ChartLegend.tsx
@@ -1,0 +1,47 @@
+import { clsx } from 'clsx';
+
+export interface LegendItem {
+  label: string;
+  color: string;
+  active?: boolean;
+  onClick?: () => void;
+}
+
+interface ChartLegendProps {
+  items: LegendItem[];
+  className?: string;
+}
+
+export function ChartLegend({ items, className }: ChartLegendProps) {
+  if (!items.length) return null;
+
+  return (
+    <div
+      className={clsx('flex flex-wrap items-center justify-center gap-x-4 gap-y-1', className)}
+      style={{ fontSize: 11 }}
+    >
+      {items.map((item) => (
+        <button
+          key={item.label}
+          onClick={item.onClick}
+          type="button"
+          className={clsx(
+            'flex items-center gap-1.5 transition-opacity',
+            item.active === false ? 'opacity-40 hover:opacity-60' : 'opacity-90 hover:opacity-100',
+            item.onClick ? 'cursor-pointer' : 'cursor-default'
+          )}
+        >
+          <span
+            className="inline-block rounded-full shrink-0"
+            style={{
+              width: 8,
+              height: 8,
+              backgroundColor: item.color,
+            }}
+          />
+          <span className="text-muted-foreground">{item.label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/ChartTooltip.tsx
+++ b/packages/frontend/src/components/ChartTooltip.tsx
@@ -1,0 +1,54 @@
+import { type ReactNode } from 'react';
+import { clsx } from 'clsx';
+
+export interface TooltipRow {
+  label: string;
+  value: string;
+  color?: string;
+  dot?: boolean;
+}
+
+interface ChartTooltipProps {
+  header?: ReactNode;
+  rows: TooltipRow[];
+  className?: string;
+  minWidth?: number;
+  children?: ReactNode;
+}
+
+export function ChartTooltip({ header, rows, className, minWidth = 160, children }: ChartTooltipProps) {
+  return (
+    <div
+      className={clsx(
+        'bg-card border border-border rounded-xl shadow-xl p-3 text-xs animate-in fade-in slide-in-from-top-1 duration-200',
+        className
+      )}
+      style={{ minWidth }}
+    >
+      {header && (
+        <div className="font-semibold text-foreground mb-2 border-b border-border pb-1.5">
+          {header}
+        </div>
+      )}
+      <div className="space-y-1">
+        {rows.map((row, i) => (
+          <div key={i} className="flex justify-between gap-4 items-center">
+            <span className="flex items-center gap-1.5 text-muted-foreground">
+              {row.dot && (
+                <span
+                  className="inline-block rounded-full shrink-0"
+                  style={{ width: 6, height: 6, backgroundColor: row.color || 'hsl(var(--foreground))' }}
+                />
+              )}
+              {row.label}
+            </span>
+            <span className="font-mono font-semibold tabular-nums" style={{ color: row.color }}>
+              {row.value}
+            </span>
+          </div>
+        ))}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/packages/frontend/src/components/LedgerTimelineChart.tsx
+++ b/packages/frontend/src/components/LedgerTimelineChart.tsx
@@ -19,7 +19,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   Brush,
   ResponsiveContainer,
   Cell,
@@ -29,6 +28,8 @@ import { format } from 'date-fns';
 import { Database, Download, ImageIcon, RefreshCcw, Activity } from 'lucide-react';
 import { clsx } from 'clsx';
 import { LEDGERS_QUERY } from '@/graphql/queries';
+import { ChartTooltip } from './ChartTooltip';
+import { ChartLegend } from './ChartLegend';
 
 // ── types ─────────────────────────────────────────────────────────────────────
 
@@ -71,34 +72,24 @@ function LedgerTooltip({ active, payload }: TooltipProps<number, string>) {
   if (!d) return null;
 
   return (
-    <div className="bg-card border border-border rounded-xl shadow-xl p-3 text-xs min-w-[160px]">
-      <p className="font-bold text-primary mb-1.5 font-mono">#{d.sequence}</p>
-      <p className="text-muted-foreground mb-2 border-b border-border pb-1.5">
-        {format(new Date(d.closedAt), 'MMM dd HH:mm:ss')}
-      </p>
-      <div className="space-y-1">
-        <div className="flex justify-between gap-4">
-          <span className="text-green-500">✓ Successful</span>
-          <span className="font-mono font-semibold text-green-500">{d.successfulTx}</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-red-500">✗ Failed</span>
-          <span className="font-mono font-semibold text-red-500">{d.failedTx}</span>
-        </div>
-        <div className="flex justify-between gap-4 border-t border-border pt-1.5 mt-1">
-          <span className="text-muted-foreground">Operations</span>
-          <span className="font-mono">{d.operationCount}</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">Success rate</span>
-          <span className="font-mono text-purple-500">{d.successRate}%</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">Protocol</span>
-          <span className="font-mono">v{d.protocolVersion}</span>
-        </div>
-      </div>
-    </div>
+    <ChartTooltip
+      header={
+        <span className="flex items-center gap-2">
+          <span className="text-primary font-mono">#{d.sequence}</span>
+          <span className="text-muted-foreground font-normal text-[10px]">
+            {format(new Date(d.closedAt), 'MMM dd HH:mm:ss')}
+          </span>
+        </span>
+      }
+      minWidth={170}
+      rows={[
+        { label: 'Successful', value: d.successfulTx.toLocaleString(), color: '#10b981', dot: true },
+        { label: 'Failed', value: d.failedTx.toLocaleString(), color: '#ef4444', dot: true },
+        { label: 'Operations', value: d.operationCount.toLocaleString(), dot: true },
+        { label: 'Success Rate', value: `${d.successRate}%`, color: '#8b5cf6', dot: true },
+        { label: 'Protocol', value: `v${d.protocolVersion}`, dot: true },
+      ]}
+    />
   );
 }
 
@@ -188,6 +179,12 @@ export function LedgerTimelineChart() {
     { key: 'total', label: 'Total' },
     { key: 'ops', label: 'Operations' },
   ];
+
+  const legendItems = viewMode === 'stacked'
+    ? [{ label: 'Successful', color: '#10b981' }, { label: 'Failed', color: '#ef4444' }]
+    : viewMode === 'ops'
+      ? [{ label: 'Transactions', color: 'hsl(var(--primary))' }, { label: 'Operations', color: '#10b981' }]
+      : [{ label: 'Transactions', color: 'hsl(var(--primary))' }];
 
   return (
     <div className="bg-card rounded-2xl border border-border shadow-sm overflow-hidden">
@@ -290,7 +287,7 @@ export function LedgerTimelineChart() {
               )}
 
               <Tooltip content={<LedgerTooltip />} />
-              <Legend wrapperStyle={{ fontSize: '11px', paddingTop: '8px' }} iconType="circle" iconSize={8} />
+              <ChartLegend items={legendItems} className="pt-2 pb-1" />
 
               {/* Stacked success/fail bars */}
               {viewMode === 'stacked' && (

--- a/packages/frontend/src/components/NetworkChart.tsx
+++ b/packages/frontend/src/components/NetworkChart.tsx
@@ -21,6 +21,8 @@ import { format } from 'date-fns';
 import { Download, ImageIcon, RefreshCcw } from 'lucide-react';
 import { clsx } from 'clsx';
 import { NETWORK_METRICS_QUERY } from '@/graphql/queries';
+import { ChartTooltip } from './ChartTooltip';
+import { ChartLegend } from './ChartLegend';
 
 type ActiveSeries = 'transactionCount' | 'operationCount' | 'activeAccounts' | 'averageFee';
 
@@ -37,24 +39,16 @@ function CustomTooltip({ active, payload }: TooltipProps<number, string>) {
   if (!d) return null;
 
   return (
-    <div className="bg-card border border-border rounded-xl shadow-xl p-3 text-xs min-w-[160px]">
-      <p className="font-semibold text-foreground mb-2 border-b border-border pb-1.5">
-        {format(new Date(d.timestamp), 'MMM dd HH:mm')}
-      </p>
-      <div className="space-y-1.5">
-        {SERIES.map((s) => (
-          <div key={s.key} className="flex justify-between gap-4">
-            <span style={{ color: s.color }}>{s.label}</span>
-            <span className="font-mono font-semibold">
-              {typeof d[s.key] === 'number'
-                ? d[s.key].toLocaleString()
-                : '—'}
-              {s.unit ? ` ${s.unit}` : ''}
-            </span>
-          </div>
-        ))}
-      </div>
-    </div>
+    <ChartTooltip
+      header={format(new Date(d.timestamp), 'MMM dd HH:mm')}
+      minWidth={170}
+      rows={SERIES.map((s) => ({
+        label: s.label,
+        value: `${typeof d[s.key] === 'number' ? d[s.key].toLocaleString() : '—'}${s.unit ? ` ${s.unit}` : ''}`,
+        color: s.color,
+        dot: true,
+      }))}
+    />
   );
 }
 
@@ -225,6 +219,7 @@ export function NetworkChart() {
               activeDot={{ r: 4, strokeWidth: 0, fill: series.color }}
             />
           </AreaChart>
+          <ChartLegend items={SERIES.map((s) => ({ label: s.label, color: s.color }))} className="pt-3" />
         </ResponsiveContainer>
       </div>
     </div>

--- a/packages/frontend/src/components/TopAssets.tsx
+++ b/packages/frontend/src/components/TopAssets.tsx
@@ -1,6 +1,33 @@
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, type TooltipProps } from 'recharts';
 import { useQuery } from '@apollo/client';
 import { ASSET_METRICS_QUERY } from '@/graphql/queries';
+import { ChartTooltip } from './ChartTooltip';
+
+function AssetTooltip({ active, payload }: TooltipProps<number, string>) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0]?.payload as { name: string; volume: number } | undefined;
+  if (!d) return null;
+
+  return (
+    <ChartTooltip
+      header={
+        <span className="flex items-center gap-2">
+          <span>{d.name}</span>
+          <span className="text-muted-foreground font-normal">24h Volume</span>
+        </span>
+      }
+      minWidth={160}
+      rows={[
+        {
+          label: 'Volume',
+          value: `${d.volume.toLocaleString(undefined, { maximumFractionDigits: 0 })} XLM`,
+          color: 'hsl(var(--primary))',
+          dot: true,
+        },
+      ]}
+    />
+  );
+}
 
 export function TopAssets() {
   const { data, loading } = useQuery(ASSET_METRICS_QUERY, {
@@ -78,15 +105,7 @@ export function TopAssets() {
             />
             <Tooltip
               cursor={{ fill: 'hsl(var(--muted)/0.1)' }}
-              contentStyle={{
-                backgroundColor: 'hsl(var(--card))',
-                border: '1px solid hsl(var(--border))',
-                borderRadius: '8px',
-              }}
-              formatter={(value: number) => [
-                value.toLocaleString(undefined, { maximumFractionDigits: 0 }) + ' XLM',
-                '24h Volume',
-              ]}
+              content={<AssetTooltip />}
             />
             <Bar dataKey="volume" radius={[0, 4, 4, 0]} barSize={24}>
               {chartData.map((_entry: any, index: number) => (

--- a/packages/frontend/src/components/TransactionsChart.tsx
+++ b/packages/frontend/src/components/TransactionsChart.tsx
@@ -22,7 +22,6 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   Brush,
   ResponsiveContainer,
   ReferenceLine,
@@ -43,6 +42,8 @@ import {
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { NETWORK_METRICS_QUERY } from '@/graphql/queries';
+import { ChartTooltip } from './ChartTooltip';
+import { ChartLegend, type LegendItem } from './ChartLegend';
 
 // ── types ─────────────────────────────────────────────────────────────────────
 
@@ -151,44 +152,27 @@ function generateMockData(range: TimeRange): ChartDataPoint[] {
 
 // ── custom tooltip ────────────────────────────────────────────────────────────
 
-function CustomTooltip({ active, payload, label, range }: TooltipProps<number, string> & { range: TimeRange }) {
+function CustomTooltip({ active, payload, range }: TooltipProps<number, string> & { range: TimeRange }) {
   if (!active || !payload?.length) return null;
 
   const d = payload[0]?.payload as ChartDataPoint | undefined;
   if (!d) return null;
 
+  const header = format(new Date(d.timestamp), range === '7d' || range === '30d' ? 'MMM dd, yyyy' : 'MMM dd HH:mm');
+
   return (
-    <div className="bg-card border border-border rounded-xl shadow-xl p-3 text-xs min-w-[180px]">
-      <p className="font-semibold text-foreground mb-2 border-b border-border pb-1.5">
-        {format(new Date(d.timestamp), range === '7d' || range === '30d' ? 'MMM dd, yyyy' : 'MMM dd HH:mm')}
-      </p>
-      <div className="space-y-1.5">
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">Transactions</span>
-          <span className="font-mono font-semibold">{d.transactionCount.toLocaleString()}</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-green-500">✓ Successful</span>
-          <span className="font-mono font-semibold text-green-500">{d.successfulTx.toLocaleString()}</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-red-500">✗ Failed</span>
-          <span className="font-mono font-semibold text-red-500">{d.failedTx.toLocaleString()}</span>
-        </div>
-        <div className="flex justify-between gap-4 border-t border-border pt-1.5 mt-1.5">
-          <span className="text-muted-foreground">Operations</span>
-          <span className="font-mono">{d.operationCount.toLocaleString()}</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">Avg Fee</span>
-          <span className="font-mono">{d.averageFee.toFixed(0)} str</span>
-        </div>
-        <div className="flex justify-between gap-4">
-          <span className="text-muted-foreground">Success Rate</span>
-          <span className="font-mono font-semibold text-purple-500">{d.successRate.toFixed(1)}%</span>
-        </div>
-      </div>
-    </div>
+    <ChartTooltip
+      header={header}
+      minWidth={190}
+      rows={[
+        { label: 'Transactions', value: d.transactionCount.toLocaleString(), color: 'hsl(var(--primary))', dot: true },
+        { label: 'Successful', value: d.successfulTx.toLocaleString(), color: '#10b981', dot: true },
+        { label: 'Failed', value: d.failedTx.toLocaleString(), color: '#ef4444', dot: true },
+        { label: 'Operations', value: d.operationCount.toLocaleString(), dot: true },
+        { label: 'Avg Fee', value: `${d.averageFee.toFixed(0)} str`, dot: true },
+        { label: 'Success Rate', value: `${d.successRate.toFixed(1)}%`, color: '#8b5cf6', dot: true },
+      ]}
+    />
   );
 }
 
@@ -246,6 +230,7 @@ export function TransactionsChart() {
   const [timeRange, setTimeRange] = useState<TimeRange>('24h');
   const [activeMetric, setActiveMetric] = useState<MetricKey>('transactions');
   const [showSuccessFail, setShowSuccessFail] = useState(true);
+  const [hiddenSeries, setHiddenSeries] = useState<Set<string>>(new Set());
   const chartRef = useRef<HTMLDivElement>(null);
 
   const { data, loading, refetch } = useQuery(NETWORK_METRICS_QUERY, {
@@ -289,6 +274,35 @@ export function TransactionsChart() {
 
   // Determine which series to render based on active metric
   const primaryColor = METRICS.find((m) => m.key === activeMetric)?.color ?? 'hsl(var(--primary))';
+
+  const legendItems: LegendItem[] = useMemo(() => {
+    const items: LegendItem[] = [];
+    if (activeMetric !== 'transactions' || !showSuccessFail) {
+      items.push({
+        label: METRICS.find((m) => m.key === activeMetric)?.label ?? '',
+        color: primaryColor,
+        active: !hiddenSeries.has('primary'),
+        onClick: () => toggleSeries('primary'),
+      });
+    }
+    items.push(
+      { label: 'Successful', color: '#10b981', active: !hiddenSeries.has('successfulTx'), onClick: () => toggleSeries('successfulTx') },
+      { label: 'Failed', color: '#ef4444', active: !hiddenSeries.has('failedTx'), onClick: () => toggleSeries('failedTx') },
+    );
+    if (activeMetric !== 'successRate') {
+      items.push({ label: 'Success %', color: '#8b5cf6', active: !hiddenSeries.has('successRate'), onClick: () => toggleSeries('successRate') });
+    }
+    return items;
+  }, [activeMetric, showSuccessFail, hiddenSeries, primaryColor]);
+
+  function toggleSeries(key: string) {
+    setHiddenSeries((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
 
   const tickFormatter = useCallback(
     (ts: string) => formatTimestamp(ts, timeRange),
@@ -499,10 +513,9 @@ export function TransactionsChart() {
 
               <Tooltip content={<CustomTooltip range={timeRange} />} />
 
-              <Legend
-                wrapperStyle={{ fontSize: '11px', paddingTop: '12px' }}
-                iconType="circle"
-                iconSize={8}
+              <ChartLegend
+                items={legendItems}
+                className="pt-3 pb-1"
               />
 
               {/* ── Primary series based on active metric ── */}
@@ -510,44 +523,50 @@ export function TransactionsChart() {
                 <>
                   {showSuccessFail ? (
                     <>
-                      <Bar
-                        yAxisId="left"
-                        dataKey="successfulTx"
-                        name="Successful"
-                        stackId="tx"
-                        fill="#10b981"
-                        fillOpacity={0.85}
-                        radius={[0, 0, 0, 0]}
-                        maxBarSize={20}
-                      />
-                      <Bar
-                        yAxisId="left"
-                        dataKey="failedTx"
-                        name="Failed"
-                        stackId="tx"
-                        fill="#ef4444"
-                        fillOpacity={0.85}
-                        radius={[2, 2, 0, 0]}
-                        maxBarSize={20}
-                      />
+                      {!hiddenSeries.has('successfulTx') && (
+                        <Bar
+                          yAxisId="left"
+                          dataKey="successfulTx"
+                          name="Successful"
+                          stackId="tx"
+                          fill="#10b981"
+                          fillOpacity={0.85}
+                          radius={[0, 0, 0, 0]}
+                          maxBarSize={20}
+                        />
+                      )}
+                      {!hiddenSeries.has('failedTx') && (
+                        <Bar
+                          yAxisId="left"
+                          dataKey="failedTx"
+                          name="Failed"
+                          stackId="tx"
+                          fill="#ef4444"
+                          fillOpacity={0.85}
+                          radius={[2, 2, 0, 0]}
+                          maxBarSize={20}
+                        />
+                      )}
                     </>
                   ) : (
-                    <Area
-                      yAxisId="left"
-                      type="monotone"
-                      dataKey="transactionCount"
-                      name="Transactions"
-                      stroke={primaryColor}
-                      strokeWidth={2}
-                      fill="url(#txGradient)"
-                      dot={false}
-                      activeDot={{ r: 4, strokeWidth: 0 }}
-                    />
+                    !hiddenSeries.has('primary') && (
+                      <Area
+                        yAxisId="left"
+                        type="monotone"
+                        dataKey="transactionCount"
+                        name="Transactions"
+                        stroke={primaryColor}
+                        strokeWidth={2}
+                        fill="url(#txGradient)"
+                        dot={false}
+                        activeDot={{ r: 4, strokeWidth: 0 }}
+                      />
+                    )
                   )}
                 </>
               )}
 
-              {activeMetric === 'operations' && (
+              {activeMetric === 'operations' && !hiddenSeries.has('primary') && (
                 <Area
                   yAxisId="left"
                   type="monotone"
@@ -561,7 +580,7 @@ export function TransactionsChart() {
                 />
               )}
 
-              {activeMetric === 'fees' && (
+              {activeMetric === 'fees' && !hiddenSeries.has('primary') && (
                 <Line
                   yAxisId="left"
                   type="monotone"
@@ -574,7 +593,7 @@ export function TransactionsChart() {
                 />
               )}
 
-              {activeMetric === 'successRate' && (
+              {activeMetric === 'successRate' && !hiddenSeries.has('primary') && (
                 <>
                   <Area
                     yAxisId="left"
@@ -599,7 +618,7 @@ export function TransactionsChart() {
               )}
 
               {/* Secondary: success rate line overlay (when not in successRate mode) */}
-              {activeMetric !== 'successRate' && (
+              {activeMetric !== 'successRate' && !hiddenSeries.has('successRate') && (
                 <Line
                   yAxisId="right"
                   type="monotone"

--- a/packages/frontend/src/components/__tests__/ChartLegend.test.tsx
+++ b/packages/frontend/src/components/__tests__/ChartLegend.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { ChartLegend } from '../ChartLegend';
+
+describe('ChartLegend', () => {
+  it('renders legend items with labels', () => {
+    render(<ChartLegend items={[{ label: 'Successful', color: '#10b981' }, { label: 'Failed', color: '#ef4444' }]} />);
+    expect(screen.getByText('Successful')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+  });
+
+  it('renders nothing when items is empty', () => {
+    const { container } = render(<ChartLegend items={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('calls onClick when legend item is clicked', () => {
+    const onClick = vi.fn();
+    render(<ChartLegend items={[{ label: 'Test', color: '#000', onClick }]} />);
+    fireEvent.click(screen.getByText('Test'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies dimmed opacity when active is false', () => {
+    render(<ChartLegend items={[{ label: 'Dimmed', color: '#000', active: false }]} />);
+    const btn = screen.getByText('Dimmed').closest('button');
+    expect(btn).toHaveClass('opacity-40');
+  });
+});

--- a/packages/frontend/src/components/__tests__/ChartTooltip.test.tsx
+++ b/packages/frontend/src/components/__tests__/ChartTooltip.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { ChartTooltip } from '../ChartTooltip';
+
+describe('ChartTooltip', () => {
+  it('renders header', () => {
+    render(<ChartTooltip header="Test Header" rows={[]} />);
+    expect(screen.getByText('Test Header')).toBeInTheDocument();
+  });
+
+  it('renders rows with label and value', () => {
+    render(<ChartTooltip rows={[{ label: 'Volume', value: '1,000 XLM', color: '#10b981', dot: true }]} />);
+    expect(screen.getByText('Volume')).toBeInTheDocument();
+    expect(screen.getByText('1,000 XLM')).toBeInTheDocument();
+  });
+
+  it('renders multiple rows', () => {
+    render(
+      <ChartTooltip
+        rows={[
+          { label: 'Transactions', value: '500', dot: true },
+          { label: 'Fee', value: '100 str', color: '#f59e0b', dot: true },
+        ]}
+      />
+    );
+    expect(screen.getByText('Transactions')).toBeInTheDocument();
+    expect(screen.getByText('500')).toBeInTheDocument();
+    expect(screen.getByText('Fee')).toBeInTheDocument();
+    expect(screen.getByText('100 str')).toBeInTheDocument();
+  });
+
+  it('renders children', () => {
+    render(
+      <ChartTooltip rows={[]}>
+        <div data-testid="child">Extra content</div>
+      </ChartTooltip>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/pages/Assets.tsx
+++ b/packages/frontend/src/pages/Assets.tsx
@@ -3,7 +3,8 @@ import { useQuery } from '@apollo/client';
 import { ASSET_METRICS_QUERY } from '@/graphql/queries';
 import { DataTable } from '@/components/DataTable';
 import { FilterBar, FilterRow, ToggleGroup, RangeInput } from '@/components/FilterBar';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell, type TooltipProps } from 'recharts';
+import { ChartTooltip } from '@/components/ChartTooltip';
 import { Coins, ArrowRightLeft, DollarSign, RefreshCcw, Search } from 'lucide-react';
 import { MetricCard } from '@/components/MetricCard';
 import { useFilterSort } from '@/hooks/useFilterSort';
@@ -102,6 +103,18 @@ export function Assets() {
     name: m.asset.native ? 'XLM' : m.asset.assetCode,
     volume: parseFloat(m.volume24h ?? '0'),
   }));
+
+  function VolumeTooltip({ active, payload }: TooltipProps<number, string>) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload as { name: string; volume: number } | undefined;
+    if (!d) return null;
+    return (
+      <ChartTooltip
+        header={<span>{d.name}</span>}
+        rows={[{ label: '24h Volume', value: `${d.volume.toLocaleString(undefined, { maximumFractionDigits: 0 })} XLM`, color: 'hsl(var(--primary))', dot: true }]}
+      />
+    );
+  }
 
   // ── presets ────────────────────────────────────────────────────────────────
 
@@ -343,12 +356,7 @@ export function Assets() {
                 />
                 <Tooltip
                   cursor={{ fill: 'hsl(var(--muted)/0.2)' }}
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                    fontSize: '12px',
-                  }}
+                  content={<VolumeTooltip />}
                 />
                 <Bar dataKey="volume" radius={[0, 4, 4, 0]} barSize={18}>
                   {chartData.map((_: any, index: number) => (

--- a/packages/frontend/src/pages/Ledgers.tsx
+++ b/packages/frontend/src/pages/Ledgers.tsx
@@ -13,7 +13,9 @@ import {
   CartesianGrid,
   Tooltip,
   ResponsiveContainer,
+  type TooltipProps,
 } from 'recharts';
+import { ChartTooltip } from '@/components/ChartTooltip';
 import { Database, Activity, Cpu } from 'lucide-react';
 import { MetricCard } from '@/components/MetricCard';
 import { useFilterSort } from '@/hooks/useFilterSort';
@@ -109,6 +111,21 @@ export function Ledgers() {
     txCount: l.successfulTransactionCount,
     ops: l.operationCount,
   }));
+
+  function LedgerTxTooltip({ active, payload }: TooltipProps<number, string>) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload as { sequence: number; txCount: number; ops: number } | undefined;
+    if (!d) return null;
+    return (
+      <ChartTooltip
+        header={<span className="font-mono">#{d.sequence}</span>}
+        rows={[
+          { label: 'Transactions', value: d.txCount.toLocaleString(), color: 'hsl(var(--primary))', dot: true },
+          { label: 'Operations', value: d.ops.toLocaleString(), dot: true },
+        ]}
+      />
+    );
+  }
 
   // ── presets ────────────────────────────────────────────────────────────────
 
@@ -250,13 +267,7 @@ export function Ledgers() {
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
                 <XAxis dataKey="sequence" hide />
                 <YAxis stroke="hsl(var(--muted-foreground))" fontSize={10} />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
-                />
+                <Tooltip content={<LedgerTxTooltip />} />
                 <Area
                   type="stepAfter"
                   dataKey="txCount"

--- a/packages/frontend/src/pages/Network.tsx
+++ b/packages/frontend/src/pages/Network.tsx
@@ -10,11 +10,13 @@ import {
   PieChart,
   Pie,
   Cell,
-  Legend,
+  type TooltipProps,
 } from 'recharts';
 import { NETWORK_METRICS_QUERY } from '@/graphql/queries';
 import { Activity, Zap, ShieldCheck, Clock, RefreshCcw } from 'lucide-react';
 import { MetricCard } from '@/components/MetricCard';
+import { ChartTooltip } from '@/components/ChartTooltip';
+import { ChartLegend } from '@/components/ChartLegend';
 
 const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6'];
 
@@ -33,6 +35,34 @@ export function Network() {
   ];
 
   const metrics = data?.networkMetrics || {};
+
+  function CloseTimeTooltip({ active, payload }: TooltipProps<number, string>) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload as { timestamp: string; closeTime: number } | undefined;
+    if (!d) return null;
+    return (
+      <ChartTooltip
+        header={new Date(d.timestamp).toLocaleString()}
+        rows={[{ label: 'Close Time', value: `${d.closeTime.toFixed(1)}s`, color: '#3b82f6', dot: true }]}
+      />
+    );
+  }
+
+  function OpDistTooltip({ active, payload }: TooltipProps<number, string>) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0]?.payload as { name: string; value: number } | undefined;
+    if (!d) return null;
+    const total = opData.reduce((sum: number, item: { value: number }) => sum + item.value, 0);
+    return (
+      <ChartTooltip
+        header={d.name}
+        rows={[
+          { label: 'Count', value: d.value.toLocaleString(), dot: true },
+          { label: 'Share', value: `${((d.value / total) * 100).toFixed(1)}%`, color: '#8b5cf6', dot: true },
+        ]}
+      />
+    );
+  }
 
   if (loading && !data)
     return (
@@ -119,14 +149,7 @@ export function Network() {
                   tickLine={false}
                   axisLine={false}
                 />
-                <Tooltip
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--card))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '12px',
-                    boxShadow: '0 10px 15px -3px rgba(0,0,0,0.1)',
-                  }}
-                />
+                <Tooltip content={<CloseTimeTooltip />} />
                 <Area
                   type="monotone"
                   dataKey="closeTime"
@@ -164,14 +187,8 @@ export function Network() {
                     <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
                   ))}
                 </Pie>
-                <Tooltip
-                  contentStyle={{
-                    borderRadius: '12px',
-                    border: 'none',
-                    boxShadow: '0 4px 6px -1px rgba(0,0,0,0.1)',
-                  }}
-                />
-                <Legend iconType="circle" wrapperStyle={{ paddingTop: '20px' }} />
+                <Tooltip content={<OpDistTooltip />} />
+                <ChartLegend items={opData.map((d: { name: string; value: number }, i: number) => ({ label: d.name, color: COLORS[i % COLORS.length] }))} className="pt-5" />
               </PieChart>
             </ResponsiveContainer>
           </div>


### PR DESCRIPTION
Closes #234

## Changes
- Added reusable `ChartTooltip` component with animated entrance, color dot indicators, and consistent styling
- Added reusable `ChartLegend` component with interactive toggle support and consistent design
- Updated `TransactionsChart` with interactive legend (click to toggle series visibility) and improved tooltip
- Updated `LedgerTimelineChart` with dynamic legend based on view mode and improved tooltip
- Updated `NetworkChart` with new legend and improved tooltip
- Updated `TopAssets` with custom tooltip showing asset name and formatted volume
- Replaced inline tooltip styles in `Assets`, `Ledgers`, and `Network` pages with `ChartTooltip`
- Added unit tests for `ChartTooltip` and `ChartLegend`