### PR TITLE
Add data freshness indicators (#242)

### DIFF
--- a/api/src/resolvers/index.ts
+++ b/api/src/resolvers/index.ts
@@ -144,6 +144,31 @@ export const resolvers = {
       [days]
     );
     return rows.map(r => ({ date: new Date(r.date).toISOString().split('T')[0], count: parseInt(r.count, 10) }));
+  },
+
+  dataFreshness: async () => {
+    const ledgersRes = await query("SELECT MAX(created_at) as last_updated FROM ledgers");
+    const transactionsRes = await query("SELECT MAX(created_at) as last_updated FROM transactions");
+    const operationsRes = await query("SELECT MAX(created_at) as last_updated FROM operations");
+
+    const ledgersLastUpdated = ledgersRes.rows[0].last_updated ? ledgersRes.rows[0].last_updated.toISOString() : null;
+    const transactionsLastUpdated = transactionsRes.rows[0].last_updated ? transactionsRes.rows[0].last_updated.toISOString() : null;
+    const operationsLastUpdated = operationsRes.rows[0].last_updated ? operationsRes.rows[0].last_updated.toISOString() : null;
+
+    // Dashboard freshness is the latest of all three
+    const timestamps = [
+      ledgersLastUpdated,
+      transactionsLastUpdated,
+      operationsLastUpdated
+    ].filter(Boolean);
+    const dashboardLastUpdated = timestamps.length > 0 ? timestamps.sort().reverse()[0] : null;
+
+    return {
+      ledgersLastUpdated: ledgersLastUpdated || nowIso(),
+      transactionsLastUpdated: transactionsLastUpdated || nowIso(),
+      operationsLastUpdated: operationsLastUpdated || nowIso(),
+      dashboardLastUpdated: dashboardLastUpdated || nowIso(),
+    };
   }
 };
 

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -59,6 +59,13 @@ export const typeDefs = /* GraphQL */ `
     totalLedgers: Int!
   }
 
+  type DataFreshness {
+    ledgersLastUpdated: String!
+    transactionsLastUpdated: String!
+    operationsLastUpdated: String!
+    dashboardLastUpdated: String!
+  }
+
   type AssetVolume {
     assetCode: String!
     volume: String!
@@ -87,6 +94,9 @@ export const typeDefs = /* GraphQL */ `
     
     # Aggregation helpers
     dailyTransactionCount(days: Int): [DailyCount!]!
+    
+    # Data freshness
+    dataFreshness: DataFreshness!
   }
 
   type DailyCount {

--- a/frontend/src/components/DataFreshnessIndicator.tsx
+++ b/frontend/src/components/DataFreshnessIndicator.tsx
@@ -1,0 +1,76 @@
+/**
+ * DataFreshnessIndicator component (issue #242)
+ *
+ * Displays when the last data update occurred for a dashboard section.
+ * Shows a human-readable "time ago" format with visual indicators
+ * based on data freshness (green for fresh, yellow for stale, red for very stale).
+ */
+import { useTranslation } from 'react-i18next';
+
+interface DataFreshnessIndicatorProps {
+  lastUpdated: string | null;
+  label?: string;
+}
+
+export function DataFreshnessIndicator({ lastUpdated, label }: DataFreshnessIndicatorProps) {
+  const { t, i18n } = useTranslation();
+
+  if (!lastUpdated) {
+    return null;
+  }
+
+  const now = new Date();
+  const updated = new Date(lastUpdated);
+  const diffMs = now.getTime() - updated.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  let timeAgo: string;
+  let freshnessColor: string;
+
+  if (diffMins < 1) {
+    timeAgo = t('freshness.justNow');
+    freshnessColor = 'var(--color-success)';
+  } else if (diffMins < 60) {
+    timeAgo = t('freshness.minutesAgo', { count: diffMins });
+    freshnessColor = diffMins < 5 ? 'var(--color-success)' : 'var(--color-warning)';
+  } else if (diffHours < 24) {
+    timeAgo = t('freshness.hoursAgo', { count: diffHours });
+    freshnessColor = diffHours < 2 ? 'var(--color-warning)' : 'var(--color-error)';
+  } else {
+    timeAgo = t('freshness.daysAgo', { count: diffDays });
+    freshnessColor = 'var(--color-error)';
+  }
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '6px',
+        fontSize: '12px',
+        color: 'var(--color-text-secondary)',
+      }}
+    >
+      <span
+        style={{
+          display: 'inline-block',
+          width: '8px',
+          height: '8px',
+          borderRadius: '50%',
+          backgroundColor: freshnessColor,
+          animation: 'pulse 2s infinite',
+        }}
+      />
+      {label && <span>{label}:</span>}
+      <span>{timeAgo}</span>
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0.5; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/LedgersList.tsx
+++ b/frontend/src/components/LedgersList.tsx
@@ -3,9 +3,12 @@
  *
  * Displays a paginated list of ledgers using cursor-based pagination
  * from the GraphQL API.
+ * Includes data freshness indicator (issue #242).
  */
 import { useQuery } from '@apollo/client';
 import { LEDGERS_QUERY } from '../graphql/queries';
+import { useDataFreshness } from '../hooks/useDataFreshness';
+import { DataFreshnessIndicator } from './DataFreshnessIndicator';
 import { Pagination, PageInfo } from './Pagination';
 import { TableRowSkeleton } from './Skeleton';
 import { useState } from 'react';
@@ -33,6 +36,7 @@ interface LedgersData {
 
 export function LedgersList() {
   const { t, i18n } = useTranslation();
+  const { data: freshnessData } = useDataFreshness();
   const [pageSize, setPageSize] = useState(25);
   const [after, setAfter] = useState<string | null>(null);
   const [previousCursors, setPreviousCursors] = useState<string[]>([]);
@@ -99,9 +103,21 @@ export function LedgersList() {
 
   return (
     <section className="card">
-      <h3 style={{ margin: '0 0 16px', fontSize: '16px', fontWeight: 700 }}>
-        {t('ledgers.title')}
-      </h3>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '16px',
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: '16px', fontWeight: 700 }}>
+          {t('ledgers.title')}
+        </h3>
+        <DataFreshnessIndicator
+          lastUpdated={freshnessData?.ledgersLastUpdated || null}
+        />
+      </div>
 
       {ledgers.length === 0 ? (
         <p style={{ margin: 0, fontSize: '13px', color: 'var(--color-text-muted)' }}>

--- a/frontend/src/components/TransactionsList.tsx
+++ b/frontend/src/components/TransactionsList.tsx
@@ -3,9 +3,12 @@
  *
  * Displays a paginated list of transactions using cursor-based pagination
  * from the GraphQL API.
+ * Includes data freshness indicator (issue #242).
  */
 import { useQuery } from '@apollo/client';
 import { TRANSACTIONS_QUERY } from '../graphql/queries';
+import { useDataFreshness } from '../hooks/useDataFreshness';
+import { DataFreshnessIndicator } from './DataFreshnessIndicator';
 import { Pagination, PageInfo } from './Pagination';
 import { TableRowSkeleton } from './Skeleton';
 import { useState } from 'react';
@@ -35,6 +38,7 @@ interface TransactionsData {
 
 export function TransactionsList() {
   const { t, i18n } = useTranslation();
+  const { data: freshnessData } = useDataFreshness();
   const [pageSize, setPageSize] = useState(25);
   const [after, setAfter] = useState<string | null>(null);
   const [previousCursors, setPreviousCursors] = useState<string[]>([]);
@@ -109,9 +113,21 @@ export function TransactionsList() {
 
   return (
     <section className="card">
-      <h3 style={{ margin: '0 0 16px', fontSize: '16px', fontWeight: 700 }}>
-        {t('transactions.title')}
-      </h3>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          marginBottom: '16px',
+        }}
+      >
+        <h3 style={{ margin: 0, fontSize: '16px', fontWeight: 700 }}>
+          {t('transactions.title')}
+        </h3>
+        <DataFreshnessIndicator
+          lastUpdated={freshnessData?.transactionsLastUpdated || null}
+        />
+      </div>
 
       {transactions.length === 0 ? (
         <p style={{ margin: 0, fontSize: '13px', color: 'var(--color-text-muted)' }}>

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -82,3 +82,14 @@ export const NETWORK_METRICS_QUERY = gql`
     }
   }
 `;
+
+export const DATA_FRESHNESS_QUERY = gql`
+  query GetDataFreshness {
+    dataFreshness {
+      ledgersLastUpdated
+      transactionsLastUpdated
+      operationsLastUpdated
+      dashboardLastUpdated
+    }
+  }
+`;

--- a/frontend/src/hooks/useDataFreshness.ts
+++ b/frontend/src/hooks/useDataFreshness.ts
@@ -1,0 +1,37 @@
+/**
+ * useDataFreshness hook (issue #242)
+ *
+ * Fetches data freshness timestamps for each dashboard section.
+ * Polls every 30 seconds to keep freshness indicators up to date.
+ */
+import { useQuery } from "@apollo/client";
+import { DATA_FRESHNESS_QUERY } from "../graphql/queries";
+
+export interface DataFreshness {
+  ledgersLastUpdated: string;
+  transactionsLastUpdated: string;
+  operationsLastUpdated: string;
+  dashboardLastUpdated: string;
+}
+
+export interface UseDataFreshnessResult {
+  data: DataFreshness | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useDataFreshness(): UseDataFreshnessResult {
+  const { data, loading, error } = useQuery(DATA_FRESHNESS_QUERY, {
+    pollInterval: 30_000,
+    notifyOnNetworkStatusChange: true,
+    errorPolicy: "all",
+  });
+
+  const freshness = data?.dataFreshness;
+
+  return {
+    data: freshness || null,
+    loading,
+    error: error || null,
+  };
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -75,5 +75,15 @@
     "autoRefresh": "automatische Aktualisierung alle 30s",
     "updating": "Aktualisiere…",
     "refreshChart": "Diagramm aktualisieren"
+  },
+  "freshness": {
+    "justNow": "Gerade eben",
+    "minutesAgo": "vor {{count}} Minute",
+    "minutesAgo_plural": "vor {{count}} Minuten",
+    "hoursAgo": "vor {{count}} Stunde",
+    "hoursAgo_plural": "vor {{count}} Stunden",
+    "daysAgo": "vor {{count}} Tag",
+    "daysAgo_plural": "vor {{count}} Tagen",
+    "lastUpdated": "Zuletzt aktualisiert"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -75,5 +75,15 @@
     "autoRefresh": "auto-refreshes every 30s",
     "updating": "Updating…",
     "refreshChart": "Refresh chart"
+  },
+  "freshness": {
+    "justNow": "Just now",
+    "minutesAgo": "{{count}} min ago",
+    "minutesAgo_plural": "{{count}} mins ago",
+    "hoursAgo": "{{count}} hour ago",
+    "hoursAgo_plural": "{{count}} hours ago",
+    "daysAgo": "{{count}} day ago",
+    "daysAgo_plural": "{{count}} days ago",
+    "lastUpdated": "Last updated"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -75,5 +75,15 @@
     "autoRefresh": "se actualiza automáticamente cada 30s",
     "updating": "Actualizando…",
     "refreshChart": "Actualizar gráfico"
+  },
+  "freshness": {
+    "justNow": "Ahora mismo",
+    "minutesAgo": "hace {{count}} minuto",
+    "minutesAgo_plural": "hace {{count}} minutos",
+    "hoursAgo": "hace {{count}} hora",
+    "hoursAgo_plural": "hace {{count}} horas",
+    "daysAgo": "hace {{count}} día",
+    "daysAgo_plural": "hace {{count}} días",
+    "lastUpdated": "Última actualización"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -75,5 +75,15 @@
     "autoRefresh": "actualisation automatique toutes les 30s",
     "updating": "Mise à jour…",
     "refreshChart": "Actualiser le graphique"
+  },
+  "freshness": {
+    "justNow": "À l'instant",
+    "minutesAgo": "il y a {{count}} minute",
+    "minutesAgo_plural": "il y a {{count}} minutes",
+    "hoursAgo": "il y a {{count}} heure",
+    "hoursAgo_plural": "il y a {{count}} heures",
+    "daysAgo": "il y a {{count}} jour",
+    "daysAgo_plural": "il y a {{count}} jours",
+    "lastUpdated": "Dernière mise à jour"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -75,5 +75,15 @@
     "autoRefresh": "30秒ごとに自動更新",
     "updating": "更新中…",
     "refreshChart": "チャートを更新"
+  },
+  "freshness": {
+    "justNow": "たった今",
+    "minutesAgo": "{{count}}分前",
+    "minutesAgo_plural": "{{count}}分前",
+    "hoursAgo": "{{count}}時間前",
+    "hoursAgo_plural": "{{count}}時間前",
+    "daysAgo": "{{count}}日前",
+    "daysAgo_plural": "{{count}}日前",
+    "lastUpdated": "最終更新"
   }
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -75,5 +75,15 @@
     "autoRefresh": "每30秒自动刷新",
     "updating": "更新中…",
     "refreshChart": "刷新图表"
+  },
+  "freshness": {
+    "justNow": "刚刚",
+    "minutesAgo": "{{count}}分钟前",
+    "minutesAgo_plural": "{{count}}分钟前",
+    "hoursAgo": "{{count}}小时前",
+    "hoursAgo_plural": "{{count}}小时前",
+    "daysAgo": "{{count}}天前",
+    "daysAgo_plural": "{{count}}天前",
+    "lastUpdated": "最后更新"
   }
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,12 +4,15 @@
  * Replaces stub data with real API calls via useDashboardData.
  * Handles loading states, API errors, and retry logic.
  * Now includes paginated list views for ledgers and transactions.
+ * Includes data freshness indicators (issue #242).
  */
 import { TransactionsChart } from '../components/TransactionsChart';
 import { ExportControls } from '../components/ExportControls';
 import { ThemeToggle } from '../components/ThemeToggle';
 import { LanguageSwitcher } from '../components/LanguageSwitcher';
 import { useDashboardData } from '../hooks/useDashboardData';
+import { useDataFreshness } from '../hooks/useDataFreshness';
+import { DataFreshnessIndicator } from '../components/DataFreshnessIndicator';
 import { statsToArray } from '../utils/exportUtils';
 import { LedgersList } from '../components/LedgersList';
 import { TransactionsList } from '../components/TransactionsList';
@@ -19,6 +22,7 @@ import { useTranslation } from 'react-i18next';
 
 export function DashboardPage() {
   const { data, loading, error, retry } = useDashboardData();
+  const { data: freshnessData } = useDataFreshness();
   const [activeTab, setActiveTab] = useState<'dashboard' | 'ledgers' | 'transactions'>('dashboard');
   const { t } = useTranslation();
 
@@ -116,6 +120,12 @@ export function DashboardPage() {
 
           {/* Theme toggle */}
           <ThemeToggle />
+
+          {/* Data freshness indicator */}
+          <DataFreshnessIndicator
+            lastUpdated={freshnessData?.dashboardLastUpdated || null}
+            label={t('freshness.lastUpdated')}
+          />
 
           {/* Export controls for dashboard metrics */}
           <ExportControls


### PR DESCRIPTION
Closes #242

---

- Add DataFreshness type to GraphQL schema with ledgers, transactions, operations, and dashboard timestamps
- Implement dataFreshness resolver to fetch last updated timestamps from database
- Add DATA_FRESHNESS_QUERY to fetch freshness data
- Create useDataFreshness hook for polling freshness data every 30s
- Create DataFreshnessIndicator component with visual freshness indicators (green/yellow/red dots)
- Add i18n translations for freshness labels in all 6 locales (en, de, es, fr, ja, zh)
- Integrate freshness indicators into DashboardPage, LedgersList, and TransactionsList