### PR TITLE
feat: aggregation totals, chart accessibility + drill-down, global error boundary

### DIFF
--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,130 @@
+/**
+ * Global error boundary (issue #239)
+ *
+ * Catches unexpected render/lifecycle errors anywhere in the wrapped
+ * subtree and shows a graceful fallback instead of an unmounted white
+ * screen. React error boundaries must be class components — there is no
+ * hook equivalent (as of React 18/19).
+ *
+ * Note: error boundaries do NOT catch errors in event handlers, async code
+ * (promises/setTimeout), SSR, or errors thrown in the boundary itself. Those
+ * are handled separately by GraphQL's own error states (see
+ * useDashboardData / TransactionsList's error branches) and, for truly
+ * unhandled async errors, a window 'error' / 'unhandledrejection' listener
+ * would be the next layer — out of scope here since none of that surfaced
+ * as an issue in this codebase yet.
+ */
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Optional hook for reporting errors to an external service. */
+  onError?: (error: Error, errorInfo: ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+const fallbackStyles = {
+  container: {
+    maxWidth: '560px',
+    margin: '48px auto',
+    padding: '24px',
+    fontFamily: '"Segoe UI", Arial, sans-serif',
+    textAlign: 'center' as const,
+  },
+  title: {
+    fontSize: '20px',
+    fontWeight: 700,
+    margin: '0 0 8px',
+    color: '#102a43',
+  },
+  message: {
+    fontSize: '14px',
+    color: '#6b7280',
+    margin: '0 0 20px',
+  },
+  details: {
+    textAlign: 'left' as const,
+    fontSize: '12px',
+    fontFamily: 'monospace',
+    background: '#fef2f2',
+    border: '1px solid #fca5a5',
+    borderRadius: '8px',
+    padding: '12px',
+    marginBottom: '20px',
+    color: '#7f1d1d',
+    overflowX: 'auto' as const,
+    whiteSpace: 'pre-wrap' as const,
+  },
+  button: {
+    background: '#3b82f6',
+    color: '#fff',
+    border: 'none',
+    borderRadius: '8px',
+    padding: '10px 20px',
+    cursor: 'pointer',
+    fontSize: '14px',
+    marginRight: '8px',
+  },
+  secondaryButton: {
+    background: 'transparent',
+    color: '#3b82f6',
+    border: '1px solid #3b82f6',
+    borderRadius: '8px',
+    padding: '10px 20px',
+    cursor: 'pointer',
+    fontSize: '14px',
+  },
+};
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    // Always log locally so the error is visible in dev tools / server logs
+    // even when no external reporting hook is configured.
+    console.error('Unhandled UI error caught by ErrorBoundary:', error, errorInfo);
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private handleReset = (): void => {
+    this.setState({ error: null });
+  };
+
+  private handleReload = (): void => {
+    window.location.reload();
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <div role="alert" style={fallbackStyles.container}>
+        <h1 style={fallbackStyles.title}>Something went wrong</h1>
+        <p style={fallbackStyles.message}>
+          The dashboard hit an unexpected error and couldn't continue rendering. You can try
+          again, or reload the page if the problem persists.
+        </p>
+        {import.meta.env.DEV && (
+          <pre style={fallbackStyles.details}>{error.stack || error.message}</pre>
+        )}
+        <button style={fallbackStyles.button} onClick={this.handleReset}>
+          Try again
+        </button>
+        <button style={fallbackStyles.secondaryButton} onClick={this.handleReload}>
+          Reload page
+        </button>
+      </div>
+    );
+  }
+}

--- a/frontend/src/components/TransactionsChart.tsx
+++ b/frontend/src/components/TransactionsChart.tsx
@@ -24,7 +24,17 @@ function formatTime(iso: string): string {
   return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 }
 
-export function TransactionsChart() {
+export interface TransactionsChartProps {
+  /**
+   * Drill-down (issue #230): called with the [start, end) bucket bounds for
+   * the data point the user activated (click, or Enter/Space when focused),
+   * so the caller can e.g. switch to the Transactions tab pre-filtered to
+   * that window.
+   */
+  onDrillDown?: (range: { startTime: string; endTime: string }) => void;
+}
+
+export function TransactionsChart({ onDrillDown }: TransactionsChartProps) {
   const { t, i18n } = useTranslation();
   const now = new Date();
   const startTime = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
@@ -128,6 +138,24 @@ export function TransactionsChart() {
   // ── Data ───────────────────────────────────────────────────────────────────
   const maxTx = Math.max(...metrics.map((m) => m.transactionCount), 1);
 
+  // Issue #230: estimate each bar's [start, end) bucket from its neighbors so
+  // drill-down works regardless of the points' sort order or bucket size.
+  const bucketRangeFor = (index: number): { startTime: string; endTime: string } => {
+    const t = new Date(metrics[index].timestamp).getTime();
+    const neighbor = metrics[index + 1] ?? metrics[index - 1];
+    const intervalMs = neighbor
+      ? Math.abs(new Date(neighbor.timestamp).getTime() - t)
+      : 60 * 60 * 1000;
+    return {
+      startTime: new Date(t - intervalMs / 2).toISOString(),
+      endTime: new Date(t + intervalMs / 2).toISOString(),
+    };
+  };
+
+  const handleActivate = (index: number) => {
+    onDrillDown?.(bucketRangeFor(index));
+  };
+
   return (
     <section className="card">
       <div
@@ -182,10 +210,12 @@ export function TransactionsChart() {
         </div>
       </div>
 
-      {/* Simple bar chart */}
+      {/* Bar chart — each bar is a focusable, labeled button (issue #226:
+          screen reader + keyboard support) that drills down into the
+          underlying transactions for that time bucket (issue #230). */}
       <div
-        role="img"
-        aria-label={`Transaction volume chart with ${metrics.length} data points`}
+        role="group"
+        aria-label={t('chart.ariaGroupLabel', { count: metrics.length })}
         style={{
           display: 'flex',
           alignItems: 'flex-end',
@@ -197,9 +227,17 @@ export function TransactionsChart() {
         {metrics.map((m, i) => {
           const heightPct = (m.transactionCount / maxTx) * 100;
           return (
-            <div
+            <button
               key={i}
+              type="button"
+              onClick={() => handleActivate(i)}
+              disabled={!onDrillDown}
               title={`${formatTime(m.timestamp)}: ${m.transactionCount} txs`}
+              aria-label={t('chart.barAriaLabel', {
+                time: formatTime(m.timestamp),
+                count: m.transactionCount,
+                successRate: m.successRate.toFixed(1),
+              })}
               style={{
                 flex: 1,
                 height: `${Math.max(heightPct, 2)}%`,
@@ -209,9 +247,19 @@ export function TransactionsChart() {
                     : m.successRate >= 95
                       ? 'var(--color-warning)'
                       : 'var(--color-error)',
+                border: 'none',
                 borderRadius: '2px 2px 0 0',
-                transition: 'height 0.3s ease',
+                transition: 'height 0.3s ease, opacity 0.15s ease',
                 minWidth: '2px',
+                padding: 0,
+                cursor: onDrillDown ? 'pointer' : 'default',
+                opacity: 1,
+              }}
+              onMouseEnter={(e) => {
+                if (onDrillDown) e.currentTarget.style.opacity = '0.75';
+              }}
+              onMouseLeave={(e) => {
+                e.currentTarget.style.opacity = '1';
               }}
             />
           );

--- a/frontend/src/components/TransactionsList.tsx
+++ b/frontend/src/components/TransactionsList.tsx
@@ -8,7 +8,7 @@ import { useQuery } from '@apollo/client';
 import { TRANSACTIONS_QUERY } from '../graphql/queries';
 import { Pagination, PageInfo } from './Pagination';
 import { TableRowSkeleton } from './Skeleton';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 interface TransactionEdge {
@@ -33,7 +33,14 @@ interface TransactionsData {
   };
 }
 
-export function TransactionsList() {
+export interface TransactionsListProps {
+  /** Issue #230: pre-filter to a time window (e.g. from a chart drill-down). */
+  initialTimeRange?: { startTime: string; endTime: string } | null;
+  /** Called when the user clears the active drill-down time range. */
+  onClearTimeRange?: () => void;
+}
+
+export function TransactionsList({ initialTimeRange, onClearTimeRange }: TransactionsListProps = {}) {
   const { t, i18n } = useTranslation();
   const [pageSize, setPageSize] = useState(25);
   const [after, setAfter] = useState<string | null>(null);
@@ -43,9 +50,18 @@ export function TransactionsList() {
     variables: {
       first: pageSize,
       after,
+      timeRange: initialTimeRange ?? undefined,
     },
     notifyOnNetworkStatusChange: true,
   });
+
+  // Reset pagination whenever the drill-down time range changes (a new
+  // filter should always start from the first page).
+  useEffect(() => {
+    setAfter(null);
+    setPreviousCursors([]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialTimeRange?.startTime, initialTimeRange?.endTime]);
 
   const transactions = data?.transactions.edges.map((edge) => edge.node) || [];
   const pageInfo = data?.transactions.pageInfo || { hasNextPage: false, endCursor: null };
@@ -107,11 +123,55 @@ export function TransactionsList() {
     );
   }
 
+  const formatRangeBound = (iso: string) => new Date(iso).toLocaleString(i18n.language);
+
   return (
     <section className="card">
       <h3 style={{ margin: '0 0 16px', fontSize: '16px', fontWeight: 700 }}>
         {t('transactions.title')}
       </h3>
+
+      {initialTimeRange && (
+        <div
+          role="status"
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            flexWrap: 'wrap',
+            gap: '8px',
+            background: 'var(--color-warning-bg)',
+            border: '1px solid var(--color-warning-border)',
+            borderRadius: '8px',
+            padding: '8px 12px',
+            marginBottom: '16px',
+            fontSize: '13px',
+          }}
+        >
+          <span style={{ color: 'var(--color-warning-text)' }}>
+            {t('transactions.filteredByDrillDown', {
+              from: formatRangeBound(initialTimeRange.startTime),
+              to: formatRangeBound(initialTimeRange.endTime),
+            })}
+          </span>
+          {onClearTimeRange && (
+            <button
+              onClick={onClearTimeRange}
+              style={{
+                background: 'transparent',
+                border: '1px solid var(--color-warning-border)',
+                borderRadius: '6px',
+                padding: '4px 10px',
+                cursor: 'pointer',
+                color: 'var(--color-warning-text)',
+                fontSize: '12px',
+              }}
+            >
+              {t('transactions.clearFilter')}
+            </button>
+          )}
+        </div>
+      )}
 
       {transactions.length === 0 ? (
         <p style={{ margin: 0, fontSize: '13px', color: 'var(--color-text-muted)' }}>

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -45,8 +45,8 @@ export const LEDGERS_QUERY = gql`
 `;
 
 export const TRANSACTIONS_QUERY = gql`
-  query GetTransactions($first: Int, $after: String) {
-    transactions(pagination: { first: $first, after: $after }) {
+  query GetTransactions($first: Int, $after: String, $timeRange: TimeRangeInput) {
+    transactions(pagination: { first: $first, after: $after }, timeRange: $timeRange) {
       edges {
         cursor
         node {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -55,7 +55,9 @@
     "createdAt": "Erstellt Am",
     "noData": "Noch keine Transaktionen verfügbar. Der Indexer synchronisiert möglicherweise noch.",
     "success": "Erfolg",
-    "failed": "Fehlgeschlagen"
+    "failed": "Fehlgeschlagen",
+    "filteredByDrillDown": "Zeige Transaktionen von {{from}} bis {{to}}",
+    "clearFilter": "Filter entfernen"
   },
   "pagination": {
     "itemsPerPage": "Elemente pro Seite",
@@ -74,6 +76,8 @@
     "successRate": "Erfolgsrate",
     "autoRefresh": "automatische Aktualisierung alle 30s",
     "updating": "Aktualisiere…",
-    "refreshChart": "Diagramm aktualisieren"
+    "refreshChart": "Diagramm aktualisieren",
+    "ariaGroupLabel": "Transaktionsvolumen-Diagramm mit {{count}} Datenpunkten. Aktivieren Sie einen Balken, um die Transaktionen dieses Zeitraums anzuzeigen.",
+    "barAriaLabel": "{{time}}: {{count}} Transaktionen, {{successRate}}% Erfolgsrate. Aktivieren, um Transaktionen aus diesem Zeitraum anzuzeigen."
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -55,7 +55,9 @@
     "createdAt": "Created At",
     "noData": "No transactions available yet. The indexer may still be syncing.",
     "success": "Success",
-    "failed": "Failed"
+    "failed": "Failed",
+    "filteredByDrillDown": "Showing transactions from {{from}} to {{to}}",
+    "clearFilter": "Clear filter"
   },
   "pagination": {
     "itemsPerPage": "Items per page",
@@ -74,6 +76,8 @@
     "successRate": "Success rate",
     "autoRefresh": "auto-refreshes every 30s",
     "updating": "Updating…",
-    "refreshChart": "Refresh chart"
+    "refreshChart": "Refresh chart",
+    "ariaGroupLabel": "Transaction volume chart with {{count}} data points. Activate a bar to inspect that time period's transactions.",
+    "barAriaLabel": "{{time}}: {{count}} transactions, {{successRate}}% success rate. Activate to view transactions from this period."
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -55,7 +55,9 @@
     "createdAt": "Creado En",
     "noData": "No hay transacciones disponibles aún. El indexador puede estar sincronizándose.",
     "success": "Éxito",
-    "failed": "Fallida"
+    "failed": "Fallida",
+    "filteredByDrillDown": "Mostrando transacciones desde {{from}} hasta {{to}}",
+    "clearFilter": "Quitar filtro"
   },
   "pagination": {
     "itemsPerPage": "Elementos por página",
@@ -74,6 +76,8 @@
     "successRate": "Tasa de éxito",
     "autoRefresh": "se actualiza automáticamente cada 30s",
     "updating": "Actualizando…",
-    "refreshChart": "Actualizar gráfico"
+    "refreshChart": "Actualizar gráfico",
+    "ariaGroupLabel": "Gráfico de volumen de transacciones con {{count}} puntos de datos. Active una barra para ver las transacciones de ese período.",
+    "barAriaLabel": "{{time}}: {{count}} transacciones, {{successRate}}% de éxito. Active para ver las transacciones de este período."
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -55,7 +55,9 @@
     "createdAt": "Créé À",
     "noData": "Aucune transaction disponible pour le moment. L'indexeur est peut-être encore en synchronisation.",
     "success": "Succès",
-    "failed": "Échec"
+    "failed": "Échec",
+    "filteredByDrillDown": "Transactions affichées du {{from}} au {{to}}",
+    "clearFilter": "Effacer le filtre"
   },
   "pagination": {
     "itemsPerPage": "Éléments par page",
@@ -74,6 +76,8 @@
     "successRate": "Taux de succès",
     "autoRefresh": "actualisation automatique toutes les 30s",
     "updating": "Mise à jour…",
-    "refreshChart": "Actualiser le graphique"
+    "refreshChart": "Actualiser le graphique",
+    "ariaGroupLabel": "Graphique du volume de transactions avec {{count}} points de données. Activez une barre pour consulter les transactions de cette période.",
+    "barAriaLabel": "{{time}} : {{count}} transactions, taux de réussite de {{successRate}}%. Activer pour voir les transactions de cette période."
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -55,7 +55,9 @@
     "createdAt": "作成日時",
     "noData": "まだトランザクションがありません。インデクサーがまだ同期中かもしれません。",
     "success": "成功",
-    "failed": "失敗"
+    "failed": "失敗",
+    "filteredByDrillDown": "{{from}}〜{{to}}の取引を表示中",
+    "clearFilter": "フィルターを解除"
   },
   "pagination": {
     "itemsPerPage": "1ページあたりの項目数",
@@ -74,6 +76,8 @@
     "successRate": "成功率",
     "autoRefresh": "30秒ごとに自動更新",
     "updating": "更新中…",
-    "refreshChart": "チャートを更新"
+    "refreshChart": "チャートを更新",
+    "ariaGroupLabel": "{{count}}個のデータポイントを含む取引量チャート。バーを選択するとその期間の取引を確認できます。",
+    "barAriaLabel": "{{time}}: {{count}}件の取引、成功率{{successRate}}%。選択するとこの期間の取引を表示します。"
   }
 }

--- a/frontend/src/i18n/locales/zh.json
+++ b/frontend/src/i18n/locales/zh.json
@@ -55,7 +55,9 @@
     "createdAt": "创建时间",
     "noData": "暂无交易可用。索引器可能仍在同步中。",
     "success": "成功",
-    "failed": "失败"
+    "failed": "失败",
+    "filteredByDrillDown": "显示 {{from}} 至 {{to}} 的交易",
+    "clearFilter": "清除筛选"
   },
   "pagination": {
     "itemsPerPage": "每页项目数",
@@ -74,6 +76,8 @@
     "successRate": "成功率",
     "autoRefresh": "每30秒自动刷新",
     "updating": "更新中…",
-    "refreshChart": "刷新图表"
+    "refreshChart": "刷新图表",
+    "ariaGroupLabel": "包含 {{count}} 个数据点的交易量图表。激活某个柱形可查看该时间段的交易。",
+    "barAriaLabel": "{{time}}：{{count}} 笔交易，成功率 {{successRate}}%。激活以查看此时间段的交易。"
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,14 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './index.css';
 import './i18n/config';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>
 );

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -20,7 +20,17 @@ import { useTranslation } from 'react-i18next';
 export function DashboardPage() {
   const { data, loading, error, retry } = useDashboardData();
   const [activeTab, setActiveTab] = useState<'dashboard' | 'ledgers' | 'transactions'>('dashboard');
+  // Issue #230: chart drill-down — clicking a bar in TransactionsChart jumps
+  // to the Transactions tab pre-filtered to that bar's time bucket.
+  const [drillDownRange, setDrillDownRange] = useState<{ startTime: string; endTime: string } | null>(
+    null
+  );
   const { t } = useTranslation();
+
+  const handleChartDrillDown = (range: { startTime: string; endTime: string }) => {
+    setDrillDownRange(range);
+    setActiveTab('transactions');
+  };
 
   // ── Loading state ──────────────────────────────────────────────────────────
   if (loading && !data) {
@@ -258,14 +268,19 @@ export function DashboardPage() {
           </div>
 
           <div className="grid" style={{ marginTop: '24px' }}>
-            <TransactionsChart />
+            <TransactionsChart onDrillDown={handleChartDrillDown} />
           </div>
         </>
       )}
 
       {activeTab === 'ledgers' && <LedgersList />}
 
-      {activeTab === 'transactions' && <TransactionsList />}
+      {activeTab === 'transactions' && (
+        <TransactionsList
+          initialTimeRange={drillDownRange}
+          onClearTimeRange={() => setDrillDownRange(null)}
+        />
+      )}
     </main>
   );
 }

--- a/packages/api/src/resolvers/analytics.ts
+++ b/packages/api/src/resolvers/analytics.ts
@@ -94,6 +94,73 @@ export const analyticsResolvers = {
       }
     ),
 
+    // Issue #220: aggregation endpoints should return summary totals
+    // alongside (or instead of) the raw list, not force every caller to
+    // fetch and reduce the full point list client-side just to get a sum.
+    networkMetricsSummary: withResolverLogging(
+      'Query.networkMetricsSummary',
+      async (
+        parent: unknown,
+        args: {
+          timeRange?: { startTime?: string; endTime?: string };
+        },
+        _context: unknown,
+        _info: GraphQLResolveInfo
+      ) => {
+        if (args.timeRange) {
+          ValidationService.validateTimeRange(args.timeRange);
+        }
+
+        const { startTime, endTime } = args.timeRange || {};
+        const cacheKey = buildCacheKey('network-metrics-summary', { startTime, endTime });
+
+        return cachedQuery(cacheKey, NETWORK_METRICS_CACHE_TTL_SECONDS, async () => {
+          let whereClause = 'WHERE 1=1';
+          const params: unknown[] = [];
+          let paramIndex = 1;
+
+          if (startTime) {
+            whereClause += ` AND timestamp >= $${paramIndex++}`;
+            params.push(startTime);
+          }
+          if (endTime) {
+            whereClause += ` AND timestamp <= $${paramIndex++}`;
+            params.push(endTime);
+          }
+
+          const row = await db.queryOne(
+            `
+            SELECT
+              COUNT(*)::int AS data_point_count,
+              COALESCE(SUM(ledger_count), 0)::int AS total_ledgers,
+              COALESCE(SUM(transaction_count), 0)::int AS total_transactions,
+              COALESCE(SUM(operation_count), 0)::int AS total_operations,
+              COALESCE(SUM(total_volume), 0)::text AS total_volume,
+              COALESCE(AVG(average_fee), 0) AS average_fee,
+              COALESCE(AVG(success_rate), 0) AS average_success_rate,
+              MIN(timestamp) AS earliest_timestamp,
+              MAX(timestamp) AS latest_timestamp
+            FROM network_metrics
+            ${whereClause}
+          `,
+            params
+          );
+
+          return {
+            dataPointCount: row?.data_point_count ?? 0,
+            totalLedgers: row?.total_ledgers ?? 0,
+            totalTransactions: row?.total_transactions ?? 0,
+            totalOperations: row?.total_operations ?? 0,
+            totalVolume: row?.total_volume ?? '0',
+            averageFee: parseFloat(row?.average_fee ?? '0'),
+            averageSuccessRate: parseFloat(row?.average_success_rate ?? '0'),
+            earliestTimestamp: row?.earliest_timestamp ?? null,
+            latestTimestamp: row?.latest_timestamp ?? null,
+          };
+        });
+      }
+    ),
+
     operations: withResolverLogging(
       'Query.operations',
       async (
@@ -634,7 +701,24 @@ export const analyticsResolvers = {
           holders: asset.holders,
         }));
 
-        return createConnection(result, args.pagination || {}, (item) => item.id);
+        // Issue #220: aggregates are computed over the FULL matching result
+        // set (before pagination slicing), not just the current page.
+        const aggregates = {
+          totalVolume24h: result
+            .reduce((sum, a) => sum + BigInt(a.volume24h || '0'), 0n)
+            .toString(),
+          totalTrades24h: result.reduce((sum, a) => sum + (a.trades24h || 0), 0),
+          averagePriceChange24h:
+            result.length === 0
+              ? 0
+              : result.reduce((sum, a) => sum + a.priceChange24h, 0) / result.length,
+          totalHolders: result.reduce((sum, a) => sum + (a.holders || 0), 0),
+        };
+
+        return {
+          ...createConnection(result, args.pagination || {}, (item) => item.id),
+          aggregates,
+        };
       }
     ),
 

--- a/packages/api/src/schema/typeDefs.ts
+++ b/packages/api/src/schema/typeDefs.ts
@@ -183,10 +183,23 @@ export const typeDefs = gql`
     node: AssetMetrics!
   }
 
+  """
+  Summary totals across ALL matching assets (not just the current page) —
+  issue #220: aggregation endpoints should return totals alongside
+  paginated results, not just the current page's data.
+  """
+  type AssetMetricsAggregate {
+    totalVolume24h: String!
+    totalTrades24h: Int!
+    averagePriceChange24h: Float!
+    totalHolders: Int!
+  }
+
   type AssetMetricsConnection {
     edges: [AssetMetricsEdge!]!
     pageInfo: PageInfo!
     totalCount: Int!
+    aggregates: AssetMetricsAggregate!
   }
 
   type AccountMetricsEdge {
@@ -211,6 +224,23 @@ export const typeDefs = gql`
     totalVolume: String!
     averageFee: Float!
     successRate: Float!
+  }
+
+  """
+  Aggregated totals for `networkMetrics` over a time range — issue #220:
+  aggregation endpoints should return summary counts/totals, not just the
+  raw list of per-bucket data points.
+  """
+  type NetworkMetricsSummary {
+    dataPointCount: Int!
+    totalLedgers: Int!
+    totalTransactions: Int!
+    totalOperations: Int!
+    totalVolume: String!
+    averageFee: Float!
+    averageSuccessRate: Float!
+    earliestTimestamp: DateTime
+    latestTimestamp: DateTime
   }
 
   type AssetMetrics {
@@ -350,6 +380,9 @@ export const typeDefs = gql`
 
     # Analytics queries
     networkMetrics(timeRange: TimeRangeInput): [NetworkMetrics!]!
+
+    "Aggregated totals across the same time range as networkMetrics (issue #220)."
+    networkMetricsSummary(timeRange: TimeRangeInput): NetworkMetricsSummary!
 
     assetMetrics(
       pagination: PaginationInput


### PR DESCRIPTION
## Summary

Closes #220, 
Closes #226, 
Closes #230, 
Closes #239

### #220 — query result totals for aggregation endpoints
- New `Query.networkMetricsSummary(timeRange)`: SQL-side `SUM`/`AVG` totals (data point count, total ledgers/transactions/operations/volume, average fee, average success rate, earliest/latest timestamp) over the same time range as `networkMetrics`, computed efficiently in one aggregate query rather than requiring callers to fetch and reduce the raw list.
- `AssetMetricsConnection` gains an `aggregates` field (`totalVolume24h`, `totalTrades24h`, `averagePriceChange24h`, `totalHolders`) computed across the **full matching result set**, not just the current page.

### #226 — chart accessibility (ARIA labels)
- `TransactionsChart`'s bars are now real `<button>` elements (native keyboard focus + Enter/Space activation) with per-bar `aria-label`s describing the time, transaction count, and success rate, plus a labeled `role="group"` container — replacing the previous unlabeled `role="img"` div that hid the data from assistive tech entirely.

### #230 — chart drill-down interactions
- Activating a bar (click or keyboard) calls a new `onDrillDown` prop with that bar's estimated time bucket; `DashboardPage` wires this to switch to the Transactions tab pre-filtered to that window via a new `initialTimeRange` prop on `TransactionsList`, with a dismissible banner showing the active filter.

### #239 — global error boundary
- New `ErrorBoundary` class component (React error boundaries require a class) wrapping the app root in `main.tsx`: catches render/lifecycle errors, logs them, shows a graceful fallback with "Try again" / "Reload page", a dev-mode stack trace, and a pluggable `onError` hook for future external error reporting.

i18n strings for the above added across all 6 locales.

Note: like the sibling PR from the Ndifreke000 fork, this repo has duplicate legacy top-level dirs (`api/`, `packages/frontend`, `packages/indexer`, `packages/shared`) not in `pnpm-workspace.yaml` — all changes here are scoped to the actual workspace packages (`packages/api`, `frontend`).