### PR TITLE
Add empty-state components and real-time dashboard subscriptions

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -14,11 +14,14 @@
     "dataloader": "^2.2.3",
     "express": "^5.1.0",
     "graphql": "^16.11.0",
-    "pg": "^8.16.3"
+    "graphql-ws": "^5.16.0",
+    "pg": "^8.16.3",
+    "ws": "^8.18.0"
   },
   "devDependencies": {
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
+    "@types/ws": "^8.5.12",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3"
   }

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,10 +1,15 @@
+import { createServer } from "node:http";
 import express from "express";
 import cors from "cors";
-import { buildSchema, graphql } from "graphql";
+import { buildSchema, graphql, execute, subscribe } from "graphql";
+import { WebSocketServer } from "ws";
+import { useServer } from "graphql-ws/use/ws";
 import { typeDefs } from "./schema.js";
 import { resolvers } from "./resolvers/index.js";
 import { createLoaders } from "./loaders.js";
 import { pool } from "./db.js";
+import { pubsub } from "./pubsub.js";
+import { startLedgerEventListener } from "./pg-listener.js";
 
 const app = express();
 app.use(cors());
@@ -12,6 +17,18 @@ app.use(express.json());
 
 const isProduction = process.env.NODE_ENV === "production";
 const schema = buildSchema(typeDefs);
+
+// Issue #210: attach a `subscribe` resolver to the Subscription type's
+// field(s). `buildSchema` only builds types from SDL with default field
+// resolvers, so the async-iterator-producing resolver has to be wired in
+// after the fact — there's no separate resolver map for subscriptions the
+// way there is for Query/Mutation's rootValue.
+const subscriptionType = schema.getSubscriptionType();
+if (subscriptionType) {
+  const ledgerAddedField = subscriptionType.getFields().ledgerAdded;
+  ledgerAddedField.subscribe = () => pubsub.subscribe("LEDGER_ADDED");
+  ledgerAddedField.resolve = (payload) => payload;
+}
 
 const rateLimitStore = new Map<string, { count: number; resetAt: number }>();
 const RATE_LIMIT_WINDOW = 60 * 1000;
@@ -157,6 +174,24 @@ app.post("/graphql", async (req, res) => {
 });
 
 const port = Number(process.env.PORT ?? 4000);
-app.listen(port, () => {
+
+// Use a plain http.Server (rather than app.listen) so the WebSocket
+// subscription transport can share the same port via an HTTP upgrade.
+const httpServer = createServer(app);
+
+const wsServer = new WebSocketServer({
+  server: httpServer,
+  path: "/graphql",
+});
+useServer({ schema, execute, subscribe }, wsServer);
+
+const connectionString =
+  process.env.DATABASE_URL || "postgres://postgres:postgres@localhost:5432/stellar_analytics";
+startLedgerEventListener(connectionString).catch((err) => {
+  console.error("[api] failed to start ledger event listener", err);
+});
+
+httpServer.listen(port, () => {
   console.log(`[api] GraphQL server ready at http://localhost:${port}/graphql`);
+  console.log(`[api] GraphQL subscriptions ready at ws://localhost:${port}/graphql`);
 });

--- a/api/src/pg-listener.ts
+++ b/api/src/pg-listener.ts
@@ -1,0 +1,37 @@
+import pg from "pg";
+import { pubsub } from "./pubsub.js";
+
+const { Client } = pg;
+
+/**
+ * Dedicated (non-pooled) Postgres connection that LISTENs for
+ * `ledger_events` notifications emitted by the indexer after each
+ * committed ledger write (see indexer/src/loader.ts), and republishes
+ * them on the in-process PubSub for GraphQL subscriptions (Issue #210).
+ *
+ * A separate connection is required because LISTEN/NOTIFY is
+ * connection-scoped — it can't share the query pool used for request
+ * handling.
+ */
+export async function startLedgerEventListener(connectionString: string) {
+  const client = new Client({ connectionString });
+  await client.connect();
+  await client.query("LISTEN ledger_events");
+
+  client.on("notification", (msg) => {
+    if (msg.channel !== "ledger_events" || !msg.payload) return;
+    try {
+      const payload = JSON.parse(msg.payload);
+      pubsub.publish("LEDGER_ADDED", payload);
+    } catch (err) {
+      console.warn("[api] failed to parse ledger_events payload", err);
+    }
+  });
+
+  client.on("error", (err) => {
+    console.error("[api] ledger event listener connection error", err);
+  });
+
+  console.log("[api] listening for ledger_events notifications");
+  return client;
+}

--- a/api/src/pubsub.ts
+++ b/api/src/pubsub.ts
@@ -1,0 +1,68 @@
+import { EventEmitter } from "node:events";
+
+/**
+ * Minimal in-process pub/sub with an AsyncIterator-based subscribe API,
+ * matching what graphql-js's `subscribe()` expects for a Subscription
+ * field's `subscribe` resolver — avoids pulling in `graphql-subscriptions`
+ * for a single topic (Issue #210).
+ */
+export class SimplePubSub<T = unknown> {
+  private emitter = new EventEmitter();
+
+  publish(topic: string, payload: T): void {
+    this.emitter.emit(topic, payload);
+  }
+
+  subscribe(topic: string): AsyncIterableIterator<T> {
+    const emitter = this.emitter;
+    const queue: T[] = [];
+    let pendingResolve: ((result: IteratorResult<T>) => void) | null = null;
+    let closed = false;
+
+    const listener = (payload: T) => {
+      if (pendingResolve) {
+        pendingResolve({ value: payload, done: false });
+        pendingResolve = null;
+      } else {
+        queue.push(payload);
+      }
+    };
+
+    emitter.on(topic, listener);
+
+    const iterator: AsyncIterableIterator<T> = {
+      next(): Promise<IteratorResult<T>> {
+        if (closed) {
+          return Promise.resolve({ value: undefined, done: true });
+        }
+        if (queue.length > 0) {
+          return Promise.resolve({ value: queue.shift() as T, done: false });
+        }
+        return new Promise((resolve) => {
+          pendingResolve = resolve;
+        });
+      },
+      return(): Promise<IteratorResult<T>> {
+        closed = true;
+        emitter.off(topic, listener);
+        if (pendingResolve) {
+          pendingResolve({ value: undefined, done: true });
+          pendingResolve = null;
+        }
+        return Promise.resolve({ value: undefined, done: true });
+      },
+      throw(err): Promise<IteratorResult<T>> {
+        closed = true;
+        emitter.off(topic, listener);
+        return Promise.reject(err);
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+
+    return iterator;
+  }
+}
+
+export const pubsub = new SimplePubSub();

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -98,4 +98,17 @@ export const typeDefs = /* GraphQL */ `
     status: String!
     timestamp: String!
   }
+
+  # Issue #210: real-time subscriptions, backed by Postgres LISTEN/NOTIFY
+  # (indexer emits pg_notify('ledger_events', ...) after each committed
+  # ledger write — see indexer/src/loader.ts and api/src/pg-listener.ts).
+  type LedgerAddedEvent {
+    sequence: Int!
+    transactionCount: Int!
+    closeTime: String!
+  }
+
+  type Subscription {
+    ledgerAdded: LedgerAddedEvent!
+  }
 `;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@apollo/client": "^3.11.8",
     "graphql": "^16.9.0",
+    "graphql-ws": "^5.16.0",
     "i18next": "^26.3.0",
     "i18next-browser-languagedetector": "^8.2.1",
     "react": "^18.3.1",

--- a/frontend/src/components/EmptyState.tsx
+++ b/frontend/src/components/EmptyState.tsx
@@ -1,0 +1,68 @@
+/**
+ * EmptyState component
+ *
+ * Consistent "no data yet" guidance for charts, tables, and panels, so
+ * every empty dashboard section reads the same way instead of an ad-hoc
+ * paragraph of muted text.
+ */
+export interface EmptyStateProps {
+  /** Primary message explaining there's no data. */
+  message: string;
+  /** Optional secondary hint (e.g. what to do, or why data might be missing). */
+  hint?: string;
+}
+
+export function EmptyState({ message, hint }: EmptyStateProps) {
+  return (
+    <div
+      role="status"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        textAlign: 'center',
+        padding: '32px 16px',
+        gap: '8px',
+      }}
+    >
+      <svg
+        width="32"
+        height="32"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="var(--color-text-tertiary)"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <rect x="3" y="4" width="18" height="16" rx="2" />
+        <path d="M3 9h18" />
+        <path d="M8 14h.01M12 14h.01M16 14h.01" />
+      </svg>
+      <p
+        style={{
+          margin: 0,
+          fontSize: '13px',
+          color: 'var(--color-text-secondary)',
+          maxWidth: '320px',
+        }}
+      >
+        {message}
+      </p>
+      {hint && (
+        <p
+          style={{
+            margin: 0,
+            fontSize: '12px',
+            color: 'var(--color-text-tertiary)',
+            maxWidth: '320px',
+          }}
+        >
+          {hint}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/LedgersList.tsx
+++ b/frontend/src/components/LedgersList.tsx
@@ -8,6 +8,8 @@ import { useQuery } from '@apollo/client';
 import { LEDGERS_QUERY } from '../graphql/queries';
 import { Pagination, PageInfo } from './Pagination';
 import { TableRowSkeleton } from './Skeleton';
+import { EmptyState } from './EmptyState';
+import { useLedgerAddedSubscription } from '../hooks/useLedgerAddedSubscription';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -37,12 +39,19 @@ export function LedgersList() {
   const [after, setAfter] = useState<string | null>(null);
   const [previousCursors, setPreviousCursors] = useState<string[]>([]);
 
-  const { data, loading, error } = useQuery<LedgersData>(LEDGERS_QUERY, {
+  const { data, loading, error, refetch } = useQuery<LedgersData>(LEDGERS_QUERY, {
     variables: {
       first: pageSize,
       after,
     },
     notifyOnNetworkStatusChange: true,
+  });
+
+  // Issue #210: live-refresh the first page as new ledgers are indexed.
+  // Only refetch while on page 1, so paging forward isn't disrupted by a
+  // background refresh of a different page's data.
+  useLedgerAddedSubscription(() => {
+    if (after === null) void refetch();
   });
 
   const ledgers = data?.ledgers.edges.map((edge) => edge.node) || [];
@@ -104,9 +113,7 @@ export function LedgersList() {
       </h3>
 
       {ledgers.length === 0 ? (
-        <p style={{ margin: 0, fontSize: '13px', color: 'var(--color-text-muted)' }}>
-          {t('ledgers.noData')}
-        </p>
+        <EmptyState message={t('ledgers.noData')} />
       ) : (
         <>
           <div style={{ overflowX: 'auto' }}>

--- a/frontend/src/components/TransactionsChart.tsx
+++ b/frontend/src/components/TransactionsChart.tsx
@@ -9,6 +9,7 @@ import { useQuery } from '@apollo/client';
 import { NETWORK_METRICS_QUERY } from '../graphql/queries';
 import { ExportControls } from './ExportControls';
 import { ChartSkeleton } from './Skeleton';
+import { EmptyState } from './EmptyState';
 import { useTranslation } from 'react-i18next';
 
 interface MetricPoint {
@@ -118,9 +119,7 @@ export function TransactionsChart() {
         >
           {t('chart.transactionVolume24h')}
         </h3>
-        <p style={{ margin: 0, fontSize: '13px', color: 'var(--color-text-tertiary)' }}>
-          {t('chart.noData')}
-        </p>
+        <EmptyState message={t('chart.noData')} />
       </section>
     );
   }

--- a/frontend/src/components/TransactionsList.tsx
+++ b/frontend/src/components/TransactionsList.tsx
@@ -8,6 +8,8 @@ import { useQuery } from '@apollo/client';
 import { TRANSACTIONS_QUERY } from '../graphql/queries';
 import { Pagination, PageInfo } from './Pagination';
 import { TableRowSkeleton } from './Skeleton';
+import { EmptyState } from './EmptyState';
+import { useLedgerAddedSubscription } from '../hooks/useLedgerAddedSubscription';
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -39,12 +41,18 @@ export function TransactionsList() {
   const [after, setAfter] = useState<string | null>(null);
   const [previousCursors, setPreviousCursors] = useState<string[]>([]);
 
-  const { data, loading, error } = useQuery<TransactionsData>(TRANSACTIONS_QUERY, {
+  const { data, loading, error, refetch } = useQuery<TransactionsData>(TRANSACTIONS_QUERY, {
     variables: {
       first: pageSize,
       after,
     },
     notifyOnNetworkStatusChange: true,
+  });
+
+  // Issue #210: live-refresh the first page as new transactions land
+  // (every new ledger carries its transactions with it).
+  useLedgerAddedSubscription(() => {
+    if (after === null) void refetch();
   });
 
   const transactions = data?.transactions.edges.map((edge) => edge.node) || [];
@@ -114,9 +122,7 @@ export function TransactionsList() {
       </h3>
 
       {transactions.length === 0 ? (
-        <p style={{ margin: 0, fontSize: '13px', color: 'var(--color-text-muted)' }}>
-          {t('transactions.noData')}
-        </p>
+        <EmptyState message={t('transactions.noData')} />
       ) : (
         <>
           <div style={{ overflowX: 'auto' }}>

--- a/frontend/src/graphql/client.ts
+++ b/frontend/src/graphql/client.ts
@@ -11,20 +11,47 @@ import {
   ApolloClient,
   InMemoryCache,
   createHttpLink,
+  split,
   from,
 } from "@apollo/client";
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { getMainDefinition } from "@apollo/client/utilities";
+import { createClient } from "graphql-ws";
 import { onError } from "@apollo/client/link/error";
 import { RetryLink } from "@apollo/client/link/retry";
 
 // ── HTTP link ─────────────────────────────────────────────────────────────────
 // In development the API runs on :4000; in production it is expected to be
 // served from the same origin under /graphql.
-const httpLink = createHttpLink({
-  uri:
-    typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_GRAPHQL_URL
-      ? (import.meta as any).env.VITE_GRAPHQL_URL
-      : "http://localhost:4000/graphql",
-});
+const graphqlUrl =
+  typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_GRAPHQL_URL
+    ? (import.meta as any).env.VITE_GRAPHQL_URL
+    : "http://localhost:4000/graphql";
+
+const httpLink = createHttpLink({ uri: graphqlUrl });
+
+// ── WebSocket link (Issue #210) ───────────────────────────────────────────────
+// Real-time subscriptions (ledgerAdded, ...) over graphql-ws, backed by
+// Postgres LISTEN/NOTIFY on the API side (see api/src/pg-listener.ts).
+const wsLink = new GraphQLWsLink(
+  createClient({
+    url: graphqlUrl.replace(/^http/, "ws"),
+  })
+);
+
+// Route subscription operations over the WebSocket link, everything else
+// (queries/mutations) over HTTP.
+const splitLink = split(
+  ({ query }) => {
+    const definition = getMainDefinition(query);
+    return (
+      definition.kind === "OperationDefinition" &&
+      definition.operation === "subscription"
+    );
+  },
+  wsLink,
+  httpLink
+);
 
 // ── Error link ────────────────────────────────────────────────────────────────
 const errorLink = onError(({ graphQLErrors, networkError, operation }) => {
@@ -128,7 +155,7 @@ const cache = new InMemoryCache({
 
 // ── Client ────────────────────────────────────────────────────────────────────
 export const apolloClient = new ApolloClient({
-  link: from([errorLink, retryLink, httpLink]),
+  link: from([errorLink, retryLink, splitLink]),
   cache,
   defaultOptions: {
     watchQuery: {

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -21,6 +21,20 @@ export const STATS_QUERY = gql`
   }
 `;
 
+// Issue #210: pushed over the WebSocket link whenever the indexer commits a
+// new ledger (see api/src/pg-listener.ts). Consumed by useLedgerAddedSubscription
+// to trigger a live refresh of ledgers/transactions/stats instead of relying
+// solely on polling.
+export const LEDGER_ADDED_SUBSCRIPTION = gql`
+  subscription OnLedgerAdded {
+    ledgerAdded {
+      sequence
+      transactionCount
+      closeTime
+    }
+  }
+`;
+
 export const LEDGERS_QUERY = gql`
   query GetLedgers($first: Int, $after: String) {
     ledgers(pagination: { first: $first, after: $after }) {

--- a/frontend/src/hooks/useDashboardData.ts
+++ b/frontend/src/hooks/useDashboardData.ts
@@ -10,6 +10,7 @@
  */
 import { useQuery } from "@apollo/client";
 import { STATS_QUERY } from "../graphql/queries";
+import { useLedgerAddedSubscription } from "./useLedgerAddedSubscription";
 
 export interface DashboardStats {
   network: string;
@@ -51,11 +52,18 @@ const FALLBACK: DashboardStats = {
 
 export function useDashboardData(): UseDashboardDataResult {
   const { data, loading, error, refetch } = useQuery(STATS_QUERY, {
-    // Poll every 30 s so the dashboard stays fresh without a full page reload
+    // Poll every 30 s as a fallback so the dashboard stays fresh even if the
+    // WebSocket subscription below is unavailable (proxy/firewall, etc.).
     pollInterval: 30_000,
     notifyOnNetworkStatusChange: true,
     // Return partial data while re-fetching so the UI doesn't blank out
     errorPolicy: "all",
+  });
+
+  // Issue #210: refresh immediately when the indexer commits a new ledger,
+  // instead of waiting for the next 30s poll.
+  useLedgerAddedSubscription(() => {
+    void refetch();
   });
 
   const stats = data?.stats;

--- a/frontend/src/hooks/useLedgerAddedSubscription.ts
+++ b/frontend/src/hooks/useLedgerAddedSubscription.ts
@@ -1,0 +1,36 @@
+/**
+ * useLedgerAddedSubscription (Issue #210)
+ *
+ * Subscribes to the `ledgerAdded` GraphQL subscription (pushed over
+ * WebSocket, backed by Postgres LISTEN/NOTIFY on the API — see
+ * api/src/pg-listener.ts) and invokes `onLedgerAdded` each time a new
+ * ledger is committed by the indexer.
+ *
+ * Intentionally lightweight: rather than hand-splicing the pushed event
+ * into Apollo's cache (the ledger/transaction list queries and the
+ * subscription payload don't share an identical shape today), callers
+ * typically pass a `refetch` from their own `useQuery` so a live push
+ * triggers an instant refresh instead of waiting for the next poll tick.
+ */
+import { useSubscription } from "@apollo/client";
+import { LEDGER_ADDED_SUBSCRIPTION } from "../graphql/queries";
+
+export interface LedgerAddedEvent {
+  sequence: number;
+  transactionCount: number;
+  closeTime: string;
+}
+
+export function useLedgerAddedSubscription(
+  onLedgerAdded: (event: LedgerAddedEvent) => void
+) {
+  return useSubscription<{ ledgerAdded: LedgerAddedEvent }>(
+    LEDGER_ADDED_SUBSCRIPTION,
+    {
+      onData: ({ data }) => {
+        const event = data.data?.ledgerAdded;
+        if (event) onLedgerAdded(event);
+      },
+    }
+  );
+}

--- a/indexer/src/loader.ts
+++ b/indexer/src/loader.ts
@@ -187,6 +187,24 @@ export async function writeIngestedData(
 
     await client.query("COMMIT");
 
+    // Issue #210: notify the API's real-time subscription layer that a new
+    // ledger has landed (see api/src/pg-listener.ts). Best-effort — a
+    // failure here must not roll back or fail the ingest itself.
+    try {
+      await client.query("SELECT pg_notify('ledger_events', $1)", [
+        JSON.stringify({
+          sequence: ledger.sequence,
+          transactionCount: ledger.tx_count,
+          closeTime: ledger.close_time,
+        }),
+      ]);
+    } catch (notifyError) {
+      loaderLogger.warn(
+        { error: (notifyError as Error)?.message ?? String(notifyError) },
+        "Failed to publish ledger_events notification"
+      );
+    }
+
     metrics.durationMs = Date.now() - start;
     console.log(
       `[loader] committed ledger ${ledger.sequence}: ` +


### PR DESCRIPTION
## Summary
- **#225** — Added a shared `EmptyState` component (icon + message + optional hint) and wired it into `TransactionsChart`, `TransactionsList`, and `LedgersList`, replacing the existing ad-hoc "no data" `<p>` text with consistent visual treatment.
- **#210** — Added real, push-based GraphQL subscriptions instead of blind polling:
  - Indexer emits `pg_notify('ledger_events', ...)` after each committed ledger write (`indexer/src/loader.ts`).
  - API listens on a dedicated Postgres connection (`api/src/pg-listener.ts`) and republishes on an in-process PubSub (`api/src/pubsub.ts`), exposed as a `ledgerAdded` GraphQL subscription over `graphql-ws`/WebSocket (same port, `/graphql` path, HTTP upgrade).
  - Frontend: a split Apollo Link routes subscription operations over WS and everything else over HTTP; `useLedgerAddedSubscription` triggers instant refetches in `useDashboardData`, `LedgersList`, and `TransactionsList` (kept as a fallback alongside the existing 30s poll, in case a client's network can't sustain a WebSocket).
- **#223** — Dark mode was already fully implemented (`ThemeContext`, `ThemeToggle`, `[data-theme="dark"]` CSS vars, wired into `App.tsx`/`DashboardPage.tsx`). No changes needed.

## Notes
- The frontend's GraphQL queries (`LEDGERS_QUERY`, etc.) already didn't match `api/src/schema.ts`'s actual field names/shapes before this PR (pre-existing, unrelated drift) — I didn't attempt to reconcile that. My new subscription's schema and frontend query are self-consistent since they're a new pair with no legacy shape to match.
- Didn't implement a separate "account activity" subscription stream — new-ledger pushes already trigger a stats refetch that reflects account-level aggregates (`activeAccounts24h`, etc.).

## Test plan
- [ ] `pnpm install && pnpm dev` — confirm `/graphql` accepts a WS upgrade and `ledgerAdded` fires when the indexer commits a ledger
- [ ] Manually trigger an empty result (e.g. filter transactions to nothing) and confirm the new `EmptyState` renders
- [ ] Toggle dark mode via the existing `ThemeToggle` and confirm it still works

Closes #225
Closes #223
Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GV7kHHjcVZur14umd34W28