### PR TITLE
feat: implement issues #208, #209, #219, #222 — multi-account filtering, validation, date presets, gzip compression

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@stellar-analytics/shared": "workspace:*",
     "@types/pg": "^8.20.0",
+    "compression": "^1.7.4",
     "cors": "^2.8.5",
     "dataloader": "^2.2.3",
     "express": "^5.1.0",
@@ -19,6 +20,7 @@
     "ws": "^8.18.0"
   },
   "devDependencies": {
+    "@types/compression": "^1.7.5",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/ws": "^8.5.12",

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import express from "express";
 import cors from "cors";
+import compression from "compression";
 import { buildSchema, graphql, execute, subscribe } from "graphql";
 import { WebSocketServer } from "ws";
 import { useServer } from "graphql-ws/use/ws";
@@ -13,6 +14,7 @@ import { startLedgerEventListener } from "./pg-listener.js";
 
 const app = express();
 app.use(cors());
+app.use(compression());
 app.use(express.json());
 
 const isProduction = process.env.NODE_ENV === "production";

--- a/api/src/resolvers/index.ts
+++ b/api/src/resolvers/index.ts
@@ -1,5 +1,72 @@
 import { query } from "../db.js";
 import { nowIso } from "@stellar-analytics/shared";
+import { GraphQLError } from "graphql";
+
+const VALID_STELLAR_ADDRESS = /^G[A-Z0-9]{55}$/;
+const MAX_LIMIT = 100;
+const MIN_LIMIT = 1;
+
+function validateAddress(field: string, value: string): string {
+  if (!VALID_STELLAR_ADDRESS.test(value)) {
+    throw new GraphQLError(
+      `Invalid ${field}: "${value}" is not a valid Stellar address. Addresses must start with "G" and be 56 characters long (base32 encoded).`,
+      { extensions: { code: "VALIDATION_ERROR", field } }
+    );
+  }
+  return value;
+}
+
+function validateLimit(field: string, value: number | undefined): number {
+  if (value === undefined) return 10;
+  if (!Number.isInteger(value) || value < MIN_LIMIT || value > MAX_LIMIT) {
+    throw new GraphQLError(
+      `Invalid ${field}: ${value}. Limit must be an integer between ${MIN_LIMIT} and ${MAX_LIMIT}.`,
+      { extensions: { code: "VALIDATION_ERROR", field } }
+    );
+  }
+  return value;
+}
+
+function validateCursor(field: string, cursor: string | undefined): number | null {
+  if (!cursor) return null;
+  const decoded = Buffer.from(cursor, "base64").toString("ascii");
+  const parsed = parseInt(decoded, 10);
+  if (isNaN(parsed) || parsed < 0) {
+    throw new GraphQLError(
+      `Invalid ${field}: cursor "${cursor}" is malformed. Cursor must be a valid base64-encoded numeric value.`,
+      { extensions: { code: "VALIDATION_ERROR", field } }
+    );
+  }
+  return parsed;
+}
+
+function validateDate(field: string, value: string | undefined): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (isNaN(date.getTime())) {
+    throw new GraphQLError(
+      `Invalid ${field}: "${value}" is not a valid ISO 8601 date string. Use format like "2024-01-01T00:00:00Z".`,
+      { extensions: { code: "VALIDATION_ERROR", field } }
+    );
+  }
+  return value;
+}
+
+function resolvePresetPreset(preset: string | undefined): { startTime: string; endTime: string } {
+  const now = new Date();
+  switch (preset) {
+    case "LAST_HOUR":
+      return { startTime: new Date(now.getTime() - 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case "LAST_DAY":
+      return { startTime: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case "LAST_WEEK":
+      return { startTime: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case "LAST_MONTH":
+      return { startTime: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    default:
+      return { startTime: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+  }
+}
 
 export const resolvers = {
   health: () => ({
@@ -20,7 +87,8 @@ export const resolvers = {
   },
 
   ledgers: async ({ limit = 10, cursor }: { limit?: number; cursor?: string }, context: any) => {
-    const sequenceCursor = cursor ? parseInt(Buffer.from(cursor, 'base64').toString('ascii'), 10) : null;
+    const resolvedLimit = validateLimit("limit", limit);
+    const sequenceCursor = cursor ? validateCursor("cursor", cursor) : null;
     
     let sql = "SELECT * FROM ledgers";
     const params: any[] = [];
@@ -31,16 +99,16 @@ export const resolvers = {
     }
     
     sql += " ORDER BY sequence DESC LIMIT $" + (params.length + 1);
-    params.push(limit + 1); // One extra to check for next page
+    params.push(resolvedLimit + 1);
 
     const { rows } = await query(sql, params);
     
-    const hasNextPage = rows.length > limit;
-    const nodes = hasNextPage ? rows.slice(0, limit) : rows;
+    const hasNextPage = rows.length > resolvedLimit;
+    const nodes = hasNextPage ? rows.slice(0, resolvedLimit) : rows;
     
     const edges = nodes.map((node) => ({
       node: transformLedger(node, context),
-      cursor: Buffer.from(node.sequence.toString()).toString('base64'),
+      cursor: Buffer.from(node.sequence.toString()).toString("base64"),
     }));
 
     return {
@@ -52,23 +120,40 @@ export const resolvers = {
     };
   },
 
-  transactions: async ({ address, limit = 10 }: { address?: string; limit?: number }, context: any) => {
+  transactions: async ({ address, addresses, limit = 10 }: { address?: string; addresses?: string[]; limit?: number }, context: any) => {
+    const resolvedLimit = validateLimit("limit", limit);
+
+    const allAddresses = new Set<string>();
+    if (address) {
+      allAddresses.add(validateAddress("address", address));
+    }
+    if (addresses && addresses.length > 0) {
+      for (const addr of addresses) {
+        allAddresses.add(validateAddress("address", addr));
+      }
+    }
+
+    const addrArray = Array.from(allAddresses);
+
     let sql = "SELECT * FROM transactions";
     const params: any[] = [];
-    
-    if (address) {
-      sql += " WHERE source_account = $1";
-      params.push(address);
+
+    if (addrArray.length > 0) {
+      const placeholders = addrArray.map((_, i) => `$${i + 1}`).join(", ");
+      sql += ` WHERE source_account IN (${placeholders})`;
+      params.push(...addrArray);
     }
-    
+
     sql += " ORDER BY created_at DESC LIMIT $" + (params.length + 1);
-    params.push(limit);
+    params.push(resolvedLimit);
 
     const { rows } = await query(sql, params);
     return rows.map(tx => transformTransaction(tx, context));
   },
 
   operations: async ({ type, limit = 10 }: { type?: string; limit?: number }, context: any) => {
+    const resolvedLimit = validateLimit("limit", limit);
+
     let sql = "SELECT * FROM operations";
     const params: any[] = [];
     
@@ -78,7 +163,7 @@ export const resolvers = {
     }
     
     sql += " ORDER BY created_at DESC LIMIT $" + (params.length + 1);
-    params.push(limit);
+    params.push(resolvedLimit);
 
     const { rows } = await query(sql, params);
     return rows.map(op => transformOperation(op));
@@ -86,6 +171,8 @@ export const resolvers = {
 
   // ANALYTICS
   accountStats: async ({ address }: { address: string }) => {
+    validateAddress("address", address);
+
     const txCountRes = await query("SELECT COUNT(*) FROM transactions WHERE source_account = $1", [address]);
     const volumeRes = await query("SELECT SUM(amount::numeric) as total FROM payments WHERE \"from\" = $1", [address]);
     const lastActiveRes = await query("SELECT MAX(created_at) as last FROM transactions WHERE source_account = $1", [address]);
@@ -143,9 +230,30 @@ export const resolvers = {
     };
   },
 
-  networkMetrics: async ({ timeRange }: { timeRange?: { startTime?: string; endTime?: string } }) => {
-    const startTime = timeRange?.startTime || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-    const endTime = timeRange?.endTime || new Date().toISOString();
+  networkMetrics: async ({ timeRange, preset }: { timeRange?: { startTime?: string; endTime?: string }; preset?: string }) => {
+    let startTime: string;
+    let endTime: string;
+
+    if (preset) {
+      const resolved = resolvePresetPreset(preset);
+      startTime = resolved.startTime;
+      endTime = resolved.endTime;
+    } else if (timeRange) {
+      const start = validateDate("startTime", timeRange.startTime);
+      const end = validateDate("endTime", timeRange.endTime);
+      if (start && end && new Date(start) > new Date(end)) {
+        throw new GraphQLError(
+          'Invalid time range: startTime must be before endTime.',
+          { extensions: { code: "VALIDATION_ERROR" } }
+        );
+      }
+      startTime = start || new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+      endTime = end || new Date().toISOString();
+    } else {
+      const now = new Date();
+      startTime = new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString();
+      endTime = now.toISOString();
+    }
 
     const { rows } = await query(
       `SELECT 

--- a/api/src/schema.ts
+++ b/api/src/schema.ts
@@ -83,14 +83,14 @@ export const typeDefs = /* GraphQL */ `
     # Core Queries
     ledger(sequence: Int!): Ledger
     ledgers(limit: Int, cursor: String): LedgerConnection!
-    transactions(address: String, limit: Int): [Transaction!]!
+    transactions(address: String, addresses: [String!], limit: Int): [Transaction!]!
     operations(type: String, limit: Int): [Operation!]!
     
     # Analytics
     accountStats(address: String!): AccountStats!
     networkStats: NetworkStats!
     stats: Stats!
-    networkMetrics(timeRange: TimeRangeInput): [NetworkMetrics!]!
+    networkMetrics(timeRange: TimeRangeInput, preset: TimeRangePreset): [NetworkMetrics!]!
     assetVolume(assetCode: String!, timeframe: String!): AssetVolume!
     topAccounts(limit: Int): [TopAccount!]!
     
@@ -99,6 +99,18 @@ export const typeDefs = /* GraphQL */ `
     
     # Data freshness
     dataFreshness: DataFreshness!
+  }
+
+  enum TimeRangePreset {
+    LAST_HOUR
+    LAST_DAY
+    LAST_WEEK
+    LAST_MONTH
+  }
+
+  input TimeRangeInput {
+    startTime: String
+    endTime: String
   }
 
   type DailyCount {

--- a/packages/api/src/resolvers/analytics.test.ts
+++ b/packages/api/src/resolvers/analytics.test.ts
@@ -390,4 +390,39 @@ describe('Analytics Resolvers', () => {
       expect(result.dataSource).toBe('unhealthy');
     });
   });
+
+  describe('Query.networkMetrics with date range presets', () => {
+    it('should resolve LAST_HOUR preset to the correct time range', async () => {
+      mockDb.cacheGet.mockResolvedValue(null);
+      mockDb.query.mockResolvedValue([]);
+
+      const now = new Date();
+      const lastHour = new Date(now.getTime() - 60 * 60 * 1000).toISOString();
+
+      await analyticsResolvers.Query.networkMetrics(
+        null,
+        { timeRange: { preset: 'LAST_HOUR' } },
+        {},
+        {} as any
+      );
+
+      expect(mockDb.query).toHaveBeenCalled();
+      const queryCall = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(queryCall).toContain('network_metrics');
+    });
+
+    it('should resolve LAST_DAY preset to the correct time range', async () => {
+      mockDb.cacheGet.mockResolvedValue(null);
+      mockDb.query.mockResolvedValue([]);
+
+      await analyticsResolvers.Query.networkMetrics(
+        null,
+        { timeRange: { preset: 'LAST_DAY' } },
+        {},
+        {} as any
+      );
+
+      expect(mockDb.query).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/api/src/resolvers/analytics.ts
+++ b/packages/api/src/resolvers/analytics.ts
@@ -8,6 +8,22 @@ import { Connection, PaginationArgs } from '@stellar-analytics/shared';
 import { createConnection } from '../utils/pagination';
 import { buildOrderByClause, OrderByClause } from '../utils/sorting';
 
+function resolvePreset(preset: string): { startTime: string; endTime: string } {
+  const now = new Date();
+  switch (preset) {
+    case 'LAST_HOUR':
+      return { startTime: new Date(now.getTime() - 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case 'LAST_DAY':
+      return { startTime: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case 'LAST_WEEK':
+      return { startTime: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case 'LAST_MONTH':
+      return { startTime: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    default:
+      return { startTime: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+  }
+}
+
 const OPERATION_SORT_FIELDS = new Map<string, string>([
   ['id', 'id'],
   ['createdAt', 'created_at'],
@@ -24,7 +40,7 @@ export const analyticsResolvers = {
       async (
         parent: unknown,
         args: {
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
         },
         _context: unknown,
         _info: GraphQLResolveInfo
@@ -33,8 +49,19 @@ export const analyticsResolvers = {
           ValidationService.validateTimeRange(args.timeRange);
         }
 
-        const { startTime, endTime } = args.timeRange || {};
-        const cacheKey = buildCacheKey('network-metrics', { startTime, endTime });
+        let startTime: string | undefined;
+        let endTime: string | undefined;
+
+        if (args.timeRange?.preset) {
+          const resolved = resolvePreset(args.timeRange.preset);
+          startTime = resolved.startTime;
+          endTime = resolved.endTime;
+        } else {
+          startTime = args.timeRange?.startTime;
+          endTime = args.timeRange?.endTime;
+        }
+
+        const cacheKey = buildCacheKey('network-metrics', { startTime, endTime, preset: args.timeRange?.preset });
 
         return cachedQuery(cacheKey, CACHE_TTL.NETWORK_STATS, async () => {
           let whereClause = 'WHERE 1=1';
@@ -90,7 +117,7 @@ export const analyticsResolvers = {
       async (
         parent: unknown,
         args: {
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
         },
         _context: unknown,
         _info: GraphQLResolveInfo
@@ -99,8 +126,19 @@ export const analyticsResolvers = {
           ValidationService.validateTimeRange(args.timeRange);
         }
 
-        const { startTime, endTime } = args.timeRange || {};
-        const cacheKey = buildCacheKey('network-metrics-summary', { startTime, endTime });
+        let startTime: string | undefined;
+        let endTime: string | undefined;
+
+        if (args.timeRange?.preset) {
+          const resolved = resolvePreset(args.timeRange.preset);
+          startTime = resolved.startTime;
+          endTime = resolved.endTime;
+        } else {
+          startTime = args.timeRange?.startTime;
+          endTime = args.timeRange?.endTime;
+        }
+
+        const cacheKey = buildCacheKey('network-metrics-summary', { startTime, endTime, preset: args.timeRange?.preset });
 
         return cachedQuery(cacheKey, NETWORK_METRICS_CACHE_TTL_SECONDS, async () => {
           let whereClause = 'WHERE 1=1';
@@ -155,7 +193,7 @@ export const analyticsResolvers = {
         parent: unknown,
         args: {
           pagination?: PaginationArgs;
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
           filter?: {
             type?: string;
             successful?: boolean;
@@ -174,6 +212,18 @@ export const analyticsResolvers = {
         }
         if (args.filter) {
           ValidationService.validateOperationFilter(args.filter);
+        }
+
+        let startTime: string | undefined;
+        let endTime: string | undefined;
+
+        if (args.timeRange?.preset) {
+          const resolved = resolvePreset(args.timeRange.preset);
+          startTime = resolved.startTime;
+          endTime = resolved.endTime;
+        } else {
+          startTime = args.timeRange?.startTime;
+          endTime = args.timeRange?.endTime;
         }
 
         const { startTime, endTime } = args.timeRange || {};
@@ -612,7 +662,7 @@ export const analyticsResolvers = {
             assetCode?: string;
             assetIssuer?: string;
           };
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
           orderBy?: OrderByClause[];
         },
         _context: unknown,
@@ -628,13 +678,25 @@ export const analyticsResolvers = {
           ValidationService.validateTimeRange(args.timeRange);
         }
 
+        let startTime: string | undefined;
+        let endTime: string | undefined;
+
+        if (args.timeRange?.preset) {
+          const resolved = resolvePreset(args.timeRange.preset);
+          startTime = resolved.startTime;
+          endTime = resolved.endTime;
+        } else {
+          startTime = args.timeRange?.startTime;
+          endTime = args.timeRange?.endTime;
+        }
+
         const { assetType, assetCode, assetIssuer } = args.filter || {};
-        const { startTime, endTime } = args.timeRange || {};
 
         const cacheKey = buildCacheKey('asset-metrics', {
           assetType,
           assetCode,
           assetIssuer,
+          preset: args.timeRange?.preset,
           startTime,
           endTime,
           orderBy: args.orderBy,
@@ -741,7 +803,7 @@ export const analyticsResolvers = {
         args: {
           pagination?: PaginationArgs;
           accountId: string;
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
           orderBy?: OrderByClause[];
         },
         _context: unknown,
@@ -755,11 +817,23 @@ export const analyticsResolvers = {
           ValidationService.validateTimeRange(args.timeRange);
         }
 
+        let startTime: string | undefined;
+        let endTime: string | undefined;
+
+        if (args.timeRange?.preset) {
+          const resolved = resolvePreset(args.timeRange.preset);
+          startTime = resolved.startTime;
+          endTime = resolved.endTime;
+        } else {
+          startTime = args.timeRange?.startTime;
+          endTime = args.timeRange?.endTime;
+        }
+
         const { accountId } = args;
-        const { startTime, endTime } = args.timeRange || {};
 
         const cacheKey = buildCacheKey('account-metrics', {
           accountId,
+          preset: args.timeRange?.preset,
           startTime,
           endTime,
           orderBy: args.orderBy,
@@ -881,13 +955,29 @@ export const analyticsResolvers = {
         args: {
           entityType: string;
           filter?: { successful?: boolean; minFee?: number; maxFee?: number; hasMemo?: boolean; memoType?: string };
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
           format?: string;
         },
         _context: unknown,
         _info: GraphQLResolveInfo
       ): Promise<string> => {
         const { entityType, filter, timeRange, format = 'json' } = args;
+
+        if (timeRange) {
+          ValidationService.validateTimeRange(timeRange);
+        }
+
+        let startTime: string | undefined;
+        let endTime: string | undefined;
+
+        if (timeRange?.preset) {
+          const resolved = resolvePreset(timeRange.preset);
+          startTime = resolved.startTime;
+          endTime = resolved.endTime;
+        } else {
+          startTime = timeRange?.startTime;
+          endTime = timeRange?.endTime;
+        }
 
         if (!['transactions', 'ledgers', 'operations'].includes(entityType)) {
           throw new GraphQLError(`Unsupported entity type: "${entityType}". Must be transactions, ledgers, or operations.`, {
@@ -904,7 +994,6 @@ export const analyticsResolvers = {
         let whereClause = 'WHERE 1=1';
         const params: unknown[] = [];
         let paramIndex = 1;
-        const { startTime, endTime } = timeRange || {};
 
         if (startTime) {
           whereClause += ` AND created_at >= $${paramIndex++}`;

--- a/packages/api/src/resolvers/transactions.test.ts
+++ b/packages/api/src/resolvers/transactions.test.ts
@@ -279,4 +279,46 @@ describe('Transaction Resolvers', () => {
       ).rejects.toThrow();
     });
   });
+
+  describe('Query.transactions with multiple account IDs', () => {
+    it('should filter by multiple accounts using addresses', async () => {
+      mockDb.cacheGet.mockResolvedValue(null);
+      mockDb.query.mockResolvedValue([]);
+      mockDb.queryOne.mockResolvedValue({ total: '0' });
+
+      await transactionResolvers.Query.transactions(
+        null,
+        {
+          pagination: { first: 5 },
+          filter: {
+            addresses: ['GABC123456789012345678901234567890123456789012345678901234', 'GDEF123456789012345678901234567890123456789012345678901234'],
+          },
+        },
+        {} as any,
+        {} as any
+      );
+
+      expect(mockDb.query).toHaveBeenCalled();
+      const queryCall = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(queryCall).toContain('source_account IN');
+    });
+
+    it('should use default limit when limit is not specified', async () => {
+      mockDb.cacheGet.mockResolvedValue(null);
+      mockDb.query.mockResolvedValue([]);
+      mockDb.queryOne.mockResolvedValue({ total: '0' });
+
+      await transactionResolvers.Query.transactions(
+        null,
+        {
+          pagination: { first: 5 },
+        },
+        {} as any,
+        {} as any
+      );
+
+      const queryCall = (mockDb.query as jest.Mock).mock.calls[0][0];
+      expect(queryCall).toContain('LIMIT');
+    });
+  });
 });

--- a/packages/api/src/resolvers/transactions.ts
+++ b/packages/api/src/resolvers/transactions.ts
@@ -9,6 +9,22 @@ import { buildCacheKey, cachedQuery } from '../database/cached-query';
 import { Connection } from '@stellar-analytics/shared';
 import { buildOrderByClause, OrderByClause } from '../utils/sorting';
 
+function resolvePreset(preset: string): { startTime: string; endTime: string } {
+  const now = new Date();
+  switch (preset) {
+    case 'LAST_HOUR':
+      return { startTime: new Date(now.getTime() - 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case 'LAST_DAY':
+      return { startTime: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case 'LAST_WEEK':
+      return { startTime: new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    case 'LAST_MONTH':
+      return { startTime: new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+    default:
+      return { startTime: new Date(now.getTime() - 24 * 60 * 60 * 1000).toISOString(), endTime: now.toISOString() };
+  }
+}
+
 export interface ResolverContext {
   loaders: ApiLoaders;
 }
@@ -30,13 +46,14 @@ export const transactionResolvers = {
         parent: unknown,
         args: {
           pagination?: PaginationArgs;
-          timeRange?: { startTime?: string; endTime?: string };
+          timeRange?: { startTime?: string; endTime?: string; preset?: string };
           filter?: {
             successful?: boolean;
             minFee?: number;
             maxFee?: number;
             hasMemo?: boolean;
             memoType?: string;
+            addresses?: string[];
           };
           orderBy?: OrderByClause[];
         },
@@ -51,8 +68,8 @@ export const transactionResolvers = {
           ValidationService.validateTransactionFilter(args.filter);
         }
 
-        const { startTime, endTime } = args.timeRange || {};
-        const { successful, minFee, maxFee, hasMemo, memoType } = args.filter || {};
+        const { startTime, endTime, preset } = args.timeRange || {};
+        const { successful, minFee, maxFee, hasMemo, memoType, addresses } = args.filter || {};
 
         const orderByClause = buildOrderByClause(
           args.orderBy,
@@ -63,11 +80,13 @@ export const transactionResolvers = {
         const cacheKey = buildCacheKey('transactions', {
           startTime,
           endTime,
+          preset,
           successful,
           minFee,
           maxFee,
           hasMemo,
           memoType,
+          addresses,
           orderBy: args.orderBy,
         });
 
@@ -76,13 +95,21 @@ export const transactionResolvers = {
           const params: unknown[] = [];
           let paramIndex = 1;
 
-          if (startTime) {
+          if (preset) {
+            const { startTime: presetStart, endTime: presetEnd } = resolvePreset(preset);
             whereClause += ` AND created_at >= $${paramIndex++}`;
-            params.push(startTime);
-          }
-          if (endTime) {
+            params.push(presetStart);
             whereClause += ` AND created_at <= $${paramIndex++}`;
-            params.push(endTime);
+            params.push(presetEnd);
+          } else {
+            if (startTime) {
+              whereClause += ` AND created_at >= $${paramIndex++}`;
+              params.push(startTime);
+            }
+            if (endTime) {
+              whereClause += ` AND created_at <= $${paramIndex++}`;
+              params.push(endTime);
+            }
           }
           if (successful !== undefined) {
             whereClause += ` AND successful = $${paramIndex++}`;
@@ -103,6 +130,12 @@ export const transactionResolvers = {
           if (memoType) {
             whereClause += ` AND memo_type = $${paramIndex++}`;
             params.push(memoType);
+          }
+          if (addresses && addresses.length > 0) {
+            const placeholders = addresses.map((_, i) => `$${paramIndex + i}`).join(', ');
+            whereClause += ` AND source_account IN (${placeholders})`;
+            params.push(...addresses);
+            paramIndex += addresses.length;
           }
 
           const query = `

--- a/packages/api/src/schema/typeDefs.ts
+++ b/packages/api/src/schema/typeDefs.ts
@@ -437,6 +437,16 @@ export const typeDefs = gql`
     startTime: DateTime
     "End of the time range (ISO 8601)"
     endTime: DateTime
+    "Preset time range for convenience"
+    preset: TimeRangePreset
+  }
+
+  "Preset time range options for faster dashboard queries"
+  enum TimeRangePreset {
+    LAST_HOUR
+    LAST_DAY
+    LAST_WEEK
+    LAST_MONTH
   }
 
   "Filter for asset queries"
@@ -473,6 +483,8 @@ export const typeDefs = gql`
     hasMemo: Boolean
     "Filter by memo type (none, text, id, hash, return)"
     memoType: String
+    "Filter by source account addresses (supports multiple accounts)"
+    addresses: [String!]
   }
 
   "Filter for operation queries"

--- a/packages/api/src/services/validation.ts
+++ b/packages/api/src/services/validation.ts
@@ -66,6 +66,7 @@ const TimeRangeValidationSchema = z
   .object({
     startTime: z.string().datetime().optional(),
     endTime: z.string().datetime().optional(),
+    preset: z.enum(['LAST_HOUR', 'LAST_DAY', 'LAST_WEEK', 'LAST_MONTH']).optional(),
   })
   .refine(
     (data) => {
@@ -120,6 +121,7 @@ const TransactionFilterValidationSchema = z
     maxFee: z.number().min(0).optional(),
     hasMemo: z.boolean().optional(),
     memoType: z.enum(['none', 'text', 'id', 'hash', 'return']).optional(),
+    addresses: z.array(AddressSchema).max(50, 'Cannot filter more than 50 addresses at once').optional(),
   })
   .refine(
     (data) => {


### PR DESCRIPTION
## Summary

This pull request addresses and resolves four issue tickets in the Stellar Analytics Dashboard:

- **#208 — Add support for filtering by multiple account IDs**: Added `addresses: [String!]` field to `TransactionFilterInput` and the root `transactions` query, allowing analytics queries to request data for several accounts at once. Updated the transaction resolver to generate an `IN` clause for multiple account IDs.

- **#209 — Improve error messages for invalid GraphQL input**: Added validation helpers (`validateAddress`, `validateLimit`, `validateCursor`, `validateDate`) in the root API resolvers that throw `GraphQLError` with `extensions.code: "VALIDATION_ERROR"` and clear, descriptive messages for malformed filters, dates, and pagination parameters.

- **#219 — Add support for date range presets**: Added `TimeRangePreset` enum (`LAST_HOUR`, `LAST_DAY`, `LAST_WEEK`, `LAST_MONTH`) and a `preset` field on `TimeRangeInput`. Updated all time-range-aware resolvers (`networkMetrics`, `networkMetricsSummary`, `operations`, `assetMetrics`, `accountMetrics`, `exportData`) to resolve presets to concrete start/end times.

- **#222 — Add gzip compression for large responses**: Added `compression` middleware to the Express server in the root API and added the `compression` and `@types/compression` dependencies to reduce bandwidth usage for large analytics exports and reports.

Closes #208
Closes #209
Closes #219
Closes #222
