### PR TITLE
feat: add router-based deep linking for report pages (#351)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-﻿# Dependencies
+# Dependencies
 node_modules/
 npm-debug.log*
 yarn-debug.log*
@@ -9,6 +9,8 @@ pnpm-debug.log*
 dist/
 build/
 *.tsbuildinfo
+*.js.map
+*.d.ts.map
 
 # Environment variables
 .env
@@ -22,10 +24,15 @@ build/
 .idea/
 *.swp
 *.swo
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
 
 # OS
 .DS_Store
 Thumbs.db
+desktop.ini
 
 # Database
 *.sqlite
@@ -44,6 +51,7 @@ pids/
 # Coverage directory used by tools like istanbul
 coverage/
 *.lcov
+.nyc_output/
 
 # Temporary folders
 tmp/
@@ -54,10 +62,27 @@ backups/**/*.dump
 backups/**/*.sha256
 backups/**/*.history
 
+# Test artifacts
+# Jest / Vitest snapshots — actual test output files (not committed baselines)
+**/__snapshots__/*.snap.bak
+# Jest coverage output
+junit.xml
+test-report.xml
+
 # Playwright — keep baseline snapshots, ignore test artefacts
 packages/e2e/test-results/
 packages/e2e/playwright-report/
+packages/e2e/.cache/
 # Actual / diff images produced during a failing visual regression run
 packages/e2e/tests/__snapshots__/**/*-actual.png
 packages/e2e/tests/__snapshots__/**/*-diff.png
 # Baseline .png files ARE committed — do not ignore them
+
+# Storybook build output
+storybook-static/
+
+# Miscellaneous generated artifacts
+*.tgz
+*.tar.gz
+.turbo/
+.cache/

--- a/packages/frontend/src/hooks/useUrlTab.ts
+++ b/packages/frontend/src/hooks/useUrlTab.ts
@@ -1,0 +1,59 @@
+/**
+ * useUrlTab
+ *
+ * Syncs a tab selection to the URL search params so users can bookmark and
+ * share links to a specific tab on a page.
+ *
+ * Usage:
+ *   const [activeTab, setActiveTab] = useUrlTab<'overview' | 'operations' | 'xdr'>(
+ *     'tab',
+ *     'overview',
+ *   );
+ *
+ * The first argument is the URL param name (e.g. "tab"), and the second is the
+ * default (fallback) value used when the param is absent or invalid.
+ *
+ * When the user navigates to ?tab=operations the hook returns 'operations'.
+ * When setActiveTab('xdr') is called the URL is updated to ?tab=xdr
+ * (using history.replaceState so the browser back-button is not polluted).
+ */
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export function useUrlTab<T extends string>(
+  paramName: string,
+  defaultTab: T,
+  validTabs?: readonly T[],
+): [T, (tab: T) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const rawParam = searchParams.get(paramName) as T | null;
+
+  // Validate against the allowed set when provided; fall back to default.
+  const activeTab: T =
+    rawParam !== null &&
+    (validTabs === undefined || (validTabs as readonly string[]).includes(rawParam))
+      ? rawParam
+      : defaultTab;
+
+  const setActiveTab = useCallback(
+    (tab: T) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (tab === defaultTab) {
+            // Remove the param when it equals the default to keep URLs clean.
+            next.delete(paramName);
+          } else {
+            next.set(paramName, tab);
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams, paramName, defaultTab],
+  );
+
+  return [activeTab, setActiveTab];
+}

--- a/packages/frontend/src/pages/AccountDetail.tsx
+++ b/packages/frontend/src/pages/AccountDetail.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useUrlTab } from '@/hooks/useUrlTab';
 import { useQuery } from '@apollo/client';
 import { format } from 'date-fns';
 import {
@@ -129,8 +130,11 @@ export function AccountDetail() {
   const { accountId } = useParams<{ accountId: string }>();
   const navigate = useNavigate();
   const [copied, setCopied] = useState(false);
-  const [activeTab, setActiveTab] = useState<'transactions' | 'balances' | 'signers'>(
-    'transactions'
+  const ACCOUNT_TABS = ['transactions', 'balances', 'signers'] as const;
+  const [activeTab, setActiveTab] = useUrlTab<'transactions' | 'balances' | 'signers'>(
+    'tab',
+    'transactions',
+    ACCOUNT_TABS,
   );
 
   const {

--- a/packages/frontend/src/pages/TransactionDetail.tsx
+++ b/packages/frontend/src/pages/TransactionDetail.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { useUrlTab } from '@/hooks/useUrlTab';
 import { useQuery } from '@apollo/client';
 import { format } from 'date-fns';
 import {
@@ -131,7 +132,12 @@ export function TransactionDetail() {
   const { hash } = useParams<{ hash: string }>();
   const navigate = useNavigate();
   const [copied, setCopied] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<'overview' | 'operations' | 'xdr'>('overview');
+  const TX_TABS = ['overview', 'operations', 'xdr'] as const;
+  const [activeTab, setActiveTab] = useUrlTab<'overview' | 'operations' | 'xdr'>(
+    'tab',
+    'overview',
+    TX_TABS,
+  );
   const [showFullXdr, setShowFullXdr] = useState<Record<string, boolean>>({});
 
   const { data, loading, error } = useQuery<TransactionData>(TRANSACTION_QUERY, {


### PR DESCRIPTION
- Add useUrlTab hook that syncs tab state to URL search params
- AccountDetail: persist active tab (transactions/balances/signers) to ?tab=
- TransactionDetail: persist active tab (overview/operations/xdr) to ?tab=
- Filters on Transactions/Accounts/Ledgers/Assets pages already deep-linkable via useFilterSort hook which reads/writes all filter state from URL params
- Update .gitignore to exclude build artifacts and test output files
closes #351 