### PR TITLE
feat: add GraphQL query cost estimation and protection (#352)

### DIFF
--- a/docs/graphql-query-limits.md
+++ b/docs/graphql-query-limits.md
@@ -1,8 +1,8 @@
-# GraphQL Query Depth Limiting
+# GraphQL Query Depth Limiting and Cost Estimation
 
-The API enforces a maximum query depth to prevent deeply nested queries from causing excessive database load or stack overflows.
+The API enforces both a maximum query **depth** and a maximum query **complexity score** to prevent expensive queries from causing excessive database load or service abuse.
 
-## Current Configuration
+## Depth Limiting
 
 Depth limiting is applied via the [graphql-depth-limit](https://github.com/stems/graphql-depth-limit) package as a GraphQL validation rule:
 
@@ -19,7 +19,7 @@ this.apolloServer = new ApolloServer({
 
 The maximum allowed depth is **10 levels**.
 
-## What Counts as Depth
+### What Counts as Depth
 
 Each nested selection set adds one level of depth. For example:
 
@@ -38,7 +38,7 @@ query {
 
 A query exceeding depth 10 is rejected before execution with a validation error.
 
-## Error Response
+### Error Response
 
 When a query exceeds the depth limit, the API returns a 400-level response with a validation error:
 
@@ -55,7 +55,60 @@ When a query exceeds the depth limit, the API returns a 400-level response with 
 }
 ```
 
-## Adjusting the Limit
+---
+
+## Query Cost Estimation
+
+In addition to depth limiting, the API calculates a **complexity score** for every incoming query in the `didResolveOperation` Apollo plugin hook — before any resolvers execute. Queries exceeding the configured ceiling are rejected immediately.
+
+### How Complexity is Calculated
+
+The cost calculation is implemented in `calculateQueryComplexity()` in `packages/api/src/index.ts`:
+
+- Each selected field contributes **1 point** (multiplied by the current list multiplier).
+- Fields that resolve to **paginated collections** (`transactions`, `ledgers`, `accounts`, `operations`, `assets`, `edges`, `nodes`, `networkMetrics`, `assetMetrics`) scale the cost by the requested page size (defaults to 10 when no pagination argument is supplied).
+- The multiplier accumulates as the query nests deeper into list fields — `accounts { transactions { ... } }` compounds the cost.
+
+### Configuration
+
+| Parameter | Default | Environment Variable |
+|-----------|---------|----------------------|
+| Maximum complexity | `1000` | _(hardcoded; see `MAX_QUERY_COMPLEXITY`)_ |
+
+### `X-Query-Complexity` Response Header
+
+Every GraphQL response includes an `X-Query-Complexity` header so API clients can inspect the score of their queries and tune them proactively before reaching the hard limit:
+
+```
+X-Query-Complexity: 42
+```
+
+### Error Response
+
+When a query exceeds the complexity limit, the API returns a `400`-level GraphQL error:
+
+```json
+{
+  "errors": [
+    {
+      "message": "Query complexity 1200 exceeds the maximum allowed complexity of 1000. Reduce the number of requested fields or lower the pagination limit.",
+      "extensions": {
+        "code": "INTERNAL_SERVER_ERROR"
+      }
+    }
+  ]
+}
+```
+
+### Reducing Query Complexity
+
+- Request only the fields you need — unused fields still contribute to the score.
+- Lower the `first`/`pagination.first` argument on list fields.
+- Avoid deeply nested list-within-list queries (e.g. accounts → transactions → operations).
+
+---
+
+## Adjusting the Depth Limit
 
 The depth limit is hardcoded to `10` in `packages/api/src/index.ts`. To make it configurable via environment variable:
 
@@ -72,10 +125,6 @@ Then add to your `.env`:
 ```env
 GRAPHQL_MAX_DEPTH=10
 ```
-
-## Query Complexity
-
-Depth limiting alone does not protect against wide queries (many fields at the same level) or queries that fan out through lists. For more comprehensive protection, consider adding [graphql-query-complexity](https://github.com/slicknode/graphql-query-complexity) alongside depth limiting.
 
 ## Introspection
 

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -27,6 +27,14 @@ import { mountAdminGraphQL } from './admin/server';
 const { version: API_VERSION } = require('../package.json');
 import { getDbCircuitBreaker } from './services/circuit-breaker';
 import { AuthDirective } from './directives/auth';
+import {
+  type TraceContext,
+  createTraceContext,
+  logTrace,
+  extractTraceId,
+  getTraceResponseHeader,
+} from './utils/tracer';
+import { verify } from 'jsonwebtoken';
 
 dotenv.config();
 
@@ -565,11 +573,18 @@ class ApiServer {
               if (trace) {
                 trace.operationName = operation;
               }
+
+              // Calculate query complexity from the parsed document
+              const complexity = calculateQueryComplexity(
+                ctx.document,
+                ctx.request.variables,
+              );
               
               logger.info('GraphQL operation resolved', {
                 operation,
                 userId,
                 traceId: trace?.requestId,
+                complexity,
                 variables: ctx.request.variables,
               });
 
@@ -579,6 +594,9 @@ class ApiServer {
                     `Reduce the number of requested fields or lower the pagination limit.`
                 );
               }
+
+              // Stash complexity so willSendResponse can set the response header
+              ctx.context._queryComplexity = complexity;
             },
             didEncounterErrors(ctx: any) {
               logger.error('GraphQL operation errors', {
@@ -589,7 +607,14 @@ class ApiServer {
             },
             willSendResponse(ctx: any) {
               const duration = Date.now() - startTime;
-              
+              const complexity = ctx.context?._queryComplexity ?? 0;
+
+              // Expose query complexity to clients via response header so they
+              // can tune their queries before hitting the hard limit.
+              if (ctx.response?.http) {
+                ctx.response.http.headers.set('X-Query-Complexity', String(complexity));
+              }
+
               // Log trace summary for every request
               if (trace) {
                 logTrace(trace, logger);
@@ -599,7 +624,8 @@ class ApiServer {
                 logger.warn('Slow GraphQL query detected', {
                   operation: ctx.request.operationName,
                   traceId: trace?.requestId,
-                  duration,
+                  durationMs: duration,
+                  complexity,
                 });
               }
             },


### PR DESCRIPTION
- Add missing imports: TraceContext, createTraceContext, logTrace, extractTraceId, getTraceResponseHeader (from ./utils/tracer)
- Add missing import: verify from jsonwebtoken (WebSocket auth)
- Fix bug: complexity variable was referenced before being assigned; now calculated inside didResolveOperation via calculateQueryComplexity() using the parsed ctx.document and request variables
- calculateQueryComplexity() scales cost by pagination page size for list fields (transactions, ledgers, accounts, operations, assets, etc.)
- MAX_QUERY_COMPLEXITY = 1000 blocks queries that exceed the threshold with a descriptive error before any resolvers execute
- X-Query-Complexity response header exposes the score to API clients so they can tune queries before hitting the hard limit
- Update docs/graphql-query-limits.md with full cost estimation docs, scoring algorithm, response header, and tuning guidance
- Update .gitignore to exclude build artifacts and test output
closes #352 